### PR TITLE
Weight norms logging

### DIFF
--- a/configs/lra/ds_train_dense_attn_pathfinder32.sh
+++ b/configs/lra/ds_train_dense_attn_pathfinder32.sh
@@ -57,7 +57,8 @@ NCCL_TREE_THRESHOLD=0 deepspeed --include localhost:"$NODE" --master_port "$MAST
 --eval_train_data \
 --eval_test_data \
 --max_validation_samples 20000 \
---log_diagnostic_freq 5 \
+--log_diagnostic_freq 1 \
+--log_weight_norms \
 --log_activations \
 --seed "$SEED" \
 --job_name $JOB_NAME \

--- a/configs/lra/ds_train_dense_attn_pathfinder32.sh
+++ b/configs/lra/ds_train_dense_attn_pathfinder32.sh
@@ -57,7 +57,7 @@ NCCL_TREE_THRESHOLD=0 deepspeed --include localhost:"$NODE" --master_port "$MAST
 --eval_train_data \
 --eval_test_data \
 --max_validation_samples 20000 \
---log_diagnostic_freq 1 \
+--log_diagnostic_freq 5 \
 --log_weight_norms \
 --log_activations \
 --seed "$SEED" \

--- a/train_arguments.py
+++ b/train_arguments.py
@@ -185,13 +185,13 @@ def get_argument_parser():
     parser.add_argument(
         '--log_weight_norms', 
         action='store_true',
-        help='Log user-chosen norm of weights grouped by layer type'
+        help='Log user-chosen norm of parameters (weights) grouped by parameter type'
     )
     parser.add_argument(
-        '--log_norm', 
+        '--logging_norm_type', 
         type=str,
         default="L1",
-        help='Weight norm to be logged'
+        help='Vector norm of parameters (weights) to be logged. Valid options are: L1, L2, Linf'
     )
     parser.add_argument(
         '--data_path_prefix',

--- a/train_arguments.py
+++ b/train_arguments.py
@@ -360,7 +360,7 @@ def get_argument_parser():
     parser.add_argument(
         '--dict_backend',
         type=str,
-        default="gloo",
+        default="nccl",
         help='Backend for distributed training.'
     )
     return parser

--- a/train_arguments.py
+++ b/train_arguments.py
@@ -183,6 +183,17 @@ def get_argument_parser():
         help='Interval in epochs to log model weights and, possibly, activations.'
     )
     parser.add_argument(
+        '--log_weight_norms', 
+        action='store_true',
+        help='Log user-chosen norm of weights grouped by layer type'
+    )
+    parser.add_argument(
+        '--log_norm', 
+        type=str,
+        default="L1",
+        help='Weight norm to be logged'
+    )
+    parser.add_argument(
         '--data_path_prefix',
         type=str,
         default="",
@@ -349,7 +360,7 @@ def get_argument_parser():
     parser.add_argument(
         '--dict_backend',
         type=str,
-        default="nccl",
+        default="gloo",
         help='Backend for distributed training.'
     )
     return parser


### PR DESCRIPTION
Add weight norms logging with grouped layers. Resolves #2
View from the 'Scalars' tab in ClearML:
![image](https://github.com/user-attachments/assets/6827e824-bbfb-43fa-a697-aa3ae17afab6)
Added two new config options:
--log_weight_norms, boolean. Determines whether weight norms will be logged or not.
--log_norm, str. Determines which weight norm will be reported. Possible values: L1, L2, Linf.