### PR TITLE
Wandb tracking system

### DIFF
--- a/configs/lra/ds_train_dense_attn_pathfinder32.sh
+++ b/configs/lra/ds_train_dense_attn_pathfinder32.sh
@@ -59,6 +59,7 @@ NCCL_TREE_THRESHOLD=0 deepspeed --include localhost:"$NODE" --master_port "$MAST
 --max_validation_samples 20000 \
 --log_diagnostic_freq 5 \
 --log_activations \
+--tracking_system "wandb" \
 --seed "$SEED" \
 --job_name $JOB_NAME \
 --deepspeed_config "$DS_CONFIG" \

--- a/deepspeed_train.py
+++ b/deepspeed_train.py
@@ -18,7 +18,7 @@ from utils.tasks import TaskRegistry
 from train_arguments import get_argument_parser
 from utils.logger import Logger
 from utils.optimization import warmup_exp_decay_exp, cosine_poly_warmup_decay
-from train_utils import is_time_to_exit, master_process, TensorBoardWriter
+from train_utils import is_time_to_exit, master_process, TensorBoardWriter, WandBWriter
 
 from data.dataset_utils import ShardedDatasetWrapper, create_dataloader
 
@@ -480,16 +480,18 @@ def report_model_activations(args, model, data, step, bins=20, **kwargs):
             try:
                 vals = values#.mean(axis=-1)
                 val_max, val_min = vals.max(), vals.min()
-                if args.no_clearml:
+                if args.tracking_system == "tensorboard":
                     hist, bounds = values, bins
-                else:
+                    
+                elif args.tracking_system == "clearml" or args.tracking_system == "wandb":
                     hist, bounds = np.histogram(vals, bins=bins,
                                                 range=(val_min, val_max))
                     bounds = list(bounds)
                 args.tracker_logger.report_histogram(
                     title=name, series=name, values=hist, iteration=step,
                     xlabels=bounds
-                )
+                    )
+                
             except Exception as ex:
                 print(ex)
 
@@ -498,9 +500,9 @@ def report_model_weights(args, model, step, bins=20):
     if master_process(args):
         for name, param in model.named_parameters():
             values = param.detach().cpu().float().numpy()
-            if args.no_clearml:
+            if args.tracking_system == "tensorboard":
                 hist, bounds = values, bins
-            else:
+            elif args.tracking_system == "clearml" or args.tracking_system == "wandb":
                 hist, bounds = np.histogram(values, bins=bins, range=(np.nanmin(values), np.nanmax(values)))
                 bounds = list(bounds)
             args.tracker_logger.report_histogram(
@@ -847,24 +849,27 @@ def run(args, model, optimizer, start_epoch):
             )
             break
 
-
 def main():
     start = time.time()
     args = construct_arguments()
     model, optimizer = prepare_model_optimizer(args)
     if master_process(args):
         os.makedirs(args.saved_model_path, exist_ok=True)
-        # Set experiment tracking
-        if not args.no_clearml:
-            task = Task.init(project_name=args.project_name,
-                             task_name="research", reuse_last_task_id=False)
-            Task.set_random_seed(args.seed)
-            task.connect(args)
-            task.connect(args.config, 'bert_config')
-            task.connect_configuration(args.deepspeed_config,
-                                       name='deepspeed_config')
-            args.tracker_logger = task.get_logger()
-        else:
+        if args.tracking_system == "wandb":
+          wb = WandBWriter(name = args.project_name,args = args)
+          args.tracker_logger = wb
+        
+        elif args.tracking_system == "clearml":
+          task = Task.init(project_name=args.project_name,
+                            task_name="research", reuse_last_task_id=False)
+          Task.set_random_seed(args.seed)
+          task.connect(args)
+          task.connect(args.config, 'bert_config')
+          task.connect_configuration(args.deepspeed_config,
+                                      name='deepspeed_config')
+          args.tracker_logger = task.get_logger()
+
+        elif args.tracking_system == "tensorboard":
             args.tracker_logger = TensorBoardWriter(name=args.job_name,
                                                     base=args.output_dir)
 
@@ -880,5 +885,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-

--- a/deepspeed_train.py
+++ b/deepspeed_train.py
@@ -483,10 +483,13 @@ def report_model_activations(args, model, data, step, bins=20, **kwargs):
                 if args.tracking_system == "tensorboard":
                     hist, bounds = values, bins
                     
-                elif args.tracking_system == "clearml" or args.tracking_system == "wandb":
+                elif args.tracking_system == "clearml":
                     hist, bounds = np.histogram(vals, bins=bins,
                                                 range=(val_min, val_max))
                     bounds = list(bounds)
+                elif args.tracking_system == "wandb":
+                    hist, bounds = np.histogram(vals, bins=bins,
+                                                range=(val_min, val_max))
                 args.tracker_logger.report_histogram(
                     title=name, series=name, values=hist, iteration=step,
                     xlabels=bounds
@@ -502,9 +505,12 @@ def report_model_weights(args, model, step, bins=20):
             values = param.detach().cpu().float().numpy()
             if args.tracking_system == "tensorboard":
                 hist, bounds = values, bins
-            elif args.tracking_system == "clearml" or args.tracking_system == "wandb":
+            elif args.tracking_system == "clearml":
                 hist, bounds = np.histogram(values, bins=bins, range=(np.nanmin(values), np.nanmax(values)))
                 bounds = list(bounds)
+            elif args.tracking_system == "wandb":
+                hist, bounds = np.histogram(values, bins=bins, range=(np.nanmin(values), np.nanmax(values)))
+
             args.tracker_logger.report_histogram(
                 title=name, series=name, values=hist, iteration=step, 
                 xlabels=bounds

--- a/train_arguments.py
+++ b/train_arguments.py
@@ -234,9 +234,9 @@ def get_argument_parser():
         help="Max samples in an evaluation dataset to be used at eval time."
     )
     parser.add_argument(
-        '--no_clearml',
-        default=False,
-        action='store_true',
+        '--tracking_system',
+        default="clearml",
+        type=str,
         help="Don't use ClearML as experiment tracking system."
     )
     parser.add_argument(
@@ -352,4 +352,6 @@ def get_argument_parser():
         default="nccl",
         help='Backend for distributed training.'
     )
+
+
     return parser

--- a/train_utils.py
+++ b/train_utils.py
@@ -73,15 +73,12 @@ class WandBWriter:
                         xlabels: Optional[list] = None) -> None:
         values = np.nan_to_num(values)
         xlabels = np.nan_to_num(np.array(xlabels))
-        plt.bar(
-    x=xlabels[:-1],         
-    height=values,           
-    width=np.diff(xlabels), 
-    align='edge',             
-    edgecolor='black'
-)
+        xlabels = np.array(xlabels)
+        bin_centers = 0.5 * (xlabels[1:] + xlabels[:-1])
+        plt.bar(bin_centers, values, width=xlabels[1] - xlabels[0], alpha=0.7, color='blue', edgecolor='black')
         plt.title(title)
         wandb.log({title:wandb.Image(plt)})
+        plt.close()
         
 
         

--- a/train_utils.py
+++ b/train_utils.py
@@ -4,8 +4,12 @@ import argparse
 import time
 import math
 
+import matplotlib.pyplot as plt
 from scipy.stats import pearsonr, spearmanr
 
+import numpy as np
+import wandb
+from typing import Optional
 import torch
 import torch.distributed as dist
 from tensorboardX import SummaryWriter
@@ -35,6 +39,52 @@ class TensorBoardWriter:
     def report_histogram(self, title, series, values, iteration, xlabels):
         self.summary_writer.add_histogram(tag=title, values=values,
                                           global_step=iteration, bins=xlabels)
+
+class WandBWriter:        
+    def __init__(self, 
+                 name: str, 
+                 args, 
+                 base: str = "..",
+                 ):
+        self.run = wandb.init(
+            project=name,
+            name="research",
+            config={
+                          **vars(args),
+                          "bert_config": args.config,
+                          "deepspeed_config": args.deepspeed_config
+                      }
+        )
+        
+    def report_scalar(self, 
+                     title: str, 
+                     series: str, 
+                     value: float, 
+                     iteration: int) -> None:
+        wandb.log({
+            title+'/'+series: value,
+        })
+        
+    def report_histogram(self,
+                        title: str,
+                        series: str,
+                        values: list,
+                        iteration: int,
+                        xlabels: Optional[list] = None) -> None:
+        values = np.nan_to_num(values)
+        xlabels = np.nan_to_num(np.array(xlabels))
+        plt.bar(
+    x=xlabels[:-1],         
+    height=values,           
+    width=np.diff(xlabels), 
+    align='edge',             
+    edgecolor='black'
+)
+        plt.title(title)
+        wandb.log({title:wandb.Image(plt)})
+        
+
+        
 
 
 


### PR DESCRIPTION
Integrated support for the Weights and Biases (WandB) tracking system into our framework. 
The logs, graphs and histograms are now avaliable on WandB. --no_clearml flag refactored into --tracking_system argument, with "clearml" default value.  In the config bash script of run the pathfinder32 test example of this argument using can be found. Screenshots of graphs and histograms in my test runs were attached.
![photo_2025-05-22_01-12-05](https://github.com/user-attachments/assets/d968bf4f-29c3-4dc6-9813-4ac0ea6f88e9)
![photo_2025-05-22_01-12-54](https://github.com/user-attachments/assets/d1ddfb4e-eb89-4231-89fe-7a1da9449f03)
