### PR TITLE
Fix issue #4: Checkpoints cleaning

### DIFF
--- a/configs/lra/ds_train_dense_attn_pathfinder32.sh
+++ b/configs/lra/ds_train_dense_attn_pathfinder32.sh
@@ -41,7 +41,7 @@ if [ "${1-}" = "--resume" ]; then
 
   echo ">> Resuming from checkpoint: $CHECKPOINT_EPOCH_NAME"
 
-  JOB_NAME="$SUBDIR"
+  JOB_NAME="${SUBDIR}_from_epoch_${LOAD_EPOCH}_${DATESTAMP}"
 else
   # Set up for initial training
   DATESTAMP=$(date +'%Y-%m-%d_%H-%M')

--- a/configs/lra/ds_train_dense_attn_pathfinder32.sh
+++ b/configs/lra/ds_train_dense_attn_pathfinder32.sh
@@ -41,6 +41,7 @@ if [ "${1-}" = "--resume" ]; then
 
   echo ">> Resuming from checkpoint: $CHECKPOINT_EPOCH_NAME"
 
+  DATESTAMP=$(date +'%Y-%m-%d_%H-%M')
   JOB_NAME="${SUBDIR}_from_epoch_${LOAD_EPOCH}_${DATESTAMP}"
 else
   # Set up for initial training

--- a/deepspeed_train.py
+++ b/deepspeed_train.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import logging
+import shutil
 
 import numpy as np
 import random
@@ -32,6 +33,49 @@ last_global_step_from_restore = 0
 all_step_time = 0.0
 
 
+def _epoch_from_tag(tag):
+    try:
+        return int(tag.split('epoch')[1].split('_')[0])
+    except Exception:
+        return -1
+
+
+def manage_checkpoints(path, args):
+    """Prune old ckpts produced during this run according to flags."""
+    if not master_process(args):
+        return
+
+    try:
+        tags = [d for d in os.listdir(path)
+                if d.startswith("epoch")
+                and os.path.isdir(os.path.join(path, d))]
+    except FileNotFoundError:
+        return
+
+    current_run_tags = [t for t in tags if t not in args.preexisting_checkpoints]
+    if len(current_run_tags) <= args.keep_last_ckpts:
+        return
+
+    current_run_tags.sort(key=_epoch_from_tag) # oldest -> newest
+
+    protected = set()
+    for tag in current_run_tags:
+        epoch = _epoch_from_tag(tag)
+        if ((epoch - 1) % args.protect_every_k) == 0:
+            protected.add(tag)
+        if epoch in args.protect_epochs:
+            protected.add(tag)
+
+    victims = [t for t in current_run_tags[:-args.keep_last_ckpts]
+               if t not in protected]
+    for tag in victims:
+        try:
+            shutil.rmtree(os.path.join(path, tag))
+            logging.info(f"[ckpt-clean] removed {tag}")
+        except Exception as e:
+            logging.warning(f"[ckpt-clean] could not delete {tag}: {e}")
+
+
 def checkpoint_model(PATH, ckpt_id, model, epoch, last_global_step,
                      last_global_data_samples, **kwargs):
     """Utility function for checkpointing model + optimizer dictionaries
@@ -50,6 +94,7 @@ def checkpoint_model(PATH, ckpt_id, model, epoch, last_global_step,
     status_msg = 'checkpointing: PATH={}, ckpt_id={}'.format(PATH, ckpt_id)
     if success:
         logging.info(f"Success {status_msg}")
+        manage_checkpoints(PATH, model.args)
     else:
         logging.warning(f"Failure {status_msg}")
     return
@@ -722,6 +767,7 @@ def prepare_model_optimizer(args):
         args=args,
         model=model,
         model_parameters=optimizer_grouped_parameters)
+    model.args = args # let manage_checkpoints() access flags via model.args
 
     # Overwrite application configs with DeepSpeed config
     args.train_micro_batch_size_per_gpu = model.train_micro_batch_size_per_gpu(
@@ -883,6 +929,16 @@ def run(args, model, optimizer, start_epoch):
 def main():
     start = time.time()
     args = construct_arguments()
+    
+    # remember folders produced by previous runs
+    save_root = os.path.join(args.output_dir, "saved_models")
+    os.makedirs(save_root, exist_ok=True)
+    args.saved_model_path = os.path.join(save_root, args.job_name)
+    preexist = set()
+    if os.path.isdir(args.saved_model_path):
+        preexist = {d for d in os.listdir(args.saved_model_path)
+                    if d.startswith("epoch")}
+    args.preexisting_checkpoints = preexist
     model, optimizer = prepare_model_optimizer(args)
     if master_process(args):
         os.makedirs(args.saved_model_path, exist_ok=True)

--- a/deepspeed_train.py
+++ b/deepspeed_train.py
@@ -20,7 +20,7 @@ from utils.tasks import TaskRegistry
 from train_arguments import get_argument_parser
 from utils.logger import Logger
 from utils.optimization import warmup_exp_decay_exp, cosine_poly_warmup_decay
-from train_utils import is_time_to_exit, master_process, TensorBoardWriter, manage_checkpoints
+from train_utils import is_time_to_exit, master_process, TensorBoardWriter, WandBWriter, manage_checkpoints
 
 from data.dataset_utils import ShardedDatasetWrapper, create_dataloader
 

--- a/train_arguments.py
+++ b/train_arguments.py
@@ -295,6 +295,16 @@ def get_argument_parser():
         action='store_true',
         help='Log activation distributions for each parameter of the model every .'
     )
+
+    parser.add_argument("--keep_last_ckpts", type=int, default=3,
+                   help="Keep this many most-recent checkpoints (this run)")
+    parser.add_argument("--protect_every_k", type=int, default=50,
+                   help="Protect checkpoint if (epoch-1) %% K == 0")
+    parser.add_argument("--protect_epochs",
+                   type=lambda s: [int(x) for x in s.split(',') if s],
+                   default=[],
+                   help="Comma-separated epochs that must never be deleted")
+
     parser.add_argument(
         '--unpad_inputs',
         default=False,

--- a/train_arguments.py
+++ b/train_arguments.py
@@ -297,13 +297,18 @@ def get_argument_parser():
     )
 
     parser.add_argument("--keep_last_ckpts", type=int, default=3,
-                   help="Keep this many most-recent checkpoints (this run)")
-    parser.add_argument("--protect_every_k", type=int, default=50,
-                   help="Protect checkpoint if (epoch-1) %% K == 0")
-    parser.add_argument("--protect_epochs",
-                   type=lambda s: [int(x) for x in s.split(',') if s],
-                   default=[],
-                   help="Comma-separated epochs that must never be deleted")
+                        help="Keep this many most-recent checkpoints (this run) "
+                             "from deletion.")
+    parser.add_argument("--keep_ckpt_every", type=int, default=50,
+                        help="Protect checkpoint from deletion if "
+                             "(epoch-1) %% keep_ckpt_every == 0")
+    parser.add_argument("--keep_ckpt_epochs",
+                        type=lambda s: [int(x) for x in s.split(',') if s],
+                        default=[],
+                        help="Comma-separated epochs (e.g. 100,180,200) that "
+                             "must never be deleted")
+    # TODO: implement offset functionality for saving checkpoints and keeping them from deletion
+    
 
     parser.add_argument(
         '--unpad_inputs',


### PR DESCRIPTION
**TL;DR for PR:**

- **New CLI flags** (`train_arguments.py`):
  - `--keep_last_ckpts N` — keep only N newest checkpoints per run  
  - `--protect_every_k K` —  protect checkpoints created at intervals of K epochs (i.e. epochs 1, K+1, 2K+1, …)
  - `--protect_epochs [...]` — whitelist old checkpoints

- **Checkpoint rotation** (`deepspeed_train.py`):
  - Added `manage_checkpoints()` to prune old ckpts using the above flags  
  - Hooked into `checkpoint_model()`  
  - Captures “pre-existing” ckpts so prior runs aren’t touched

---