### PR TITLE
Graph naming conventions

### DIFF
--- a/deepspeed_train.py
+++ b/deepspeed_train.py
@@ -917,3 +917,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/deepspeed_train.py
+++ b/deepspeed_train.py
@@ -526,7 +526,7 @@ def report_model_weights(args, model, step, bins=20):
                 norm = torch.norm(p, p=norm_types[args.logging_norm_type]).item()
                 group_name, identifier = get_group(name)
                 args.tracker_logger.report_scalar(
-                    title=f'{args.logging_norm_type} Norm/ {group_name}',
+                    title=f':{args.logging_norm_type} Norm/ {group_name}',
                     series=identifier,
                     value=norm,
                     iteration=step

--- a/deepspeed_train.py
+++ b/deepspeed_train.py
@@ -917,4 +917,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
Move the weight norm logging graphs to the end of the ClearML 'Scalars' tab. Fixes #2