### PR TITLE
Overriding config

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,52 @@ and [how to use it](https://clear.ml/docs/latest/docs/).
 ClearML is enabled  by default, if you’d prefer not to use it, disable it by providing 
 `--no_clearml` argument in `deepspeed_train.py` params of the training script.
 
+
+In addition, you can **override any configuration parameter** directly from the command line using the `--override` flag, without modifying the original config files. This allows quick and flexible experimentation while keeping base configs unchanged.
+Each override must include the full path to the parameter, reflecting its nesting in the configuration structure.
+
+**Overriding parameters from different configuration sources is distinguished using the following prefixes:**
+
+- `cf.` - for parameters from the **Model config**
+- `ds.` - for parameters from the **DeepSpeed config**
+
+**Supported Override Types**
+
+| Type                        | Example                                                                 |
+|-----------------------------|-------------------------------------------------------------------------|
+| Integer                     | `cf.model_config.num_attention_heads=1`                                |
+| Boolean                     | `cf.model_config.local_attention=false`                                |
+| Float                       | `ds.optimizer.params.eps=1e-16`, `ds.optimizer.params.weight_decay=0.011`|
+| String                      | `cf.data.validation.inputs=input/train.src`                            |
+| Quoted String               | `cf.data.validation.labels="label/train.label"`                        |
+| List                        | `ds.optimizer.params.betas=[0.9,0.9]`                                   |
+| Dictionary                  | `cf.data.training='{"inputs":"input/valid.src","labels":"label/valid.label"}'` |
+
+
+**Notes:**
+
+- String values can be written as: "text" or text.
+- For dictionaries, use single quotes around the full JSON object.
+
+
+**Example Usage**
+
+```bash
+!ds_train_*.sh \
+  --override \
+  cf.model_config.num_attention_heads=1 \
+  cf.model_config.local_attention=false \
+  cf.data.validation.inputs=input/valid.src \
+  cf.data.validation.labels="label/valid.label" \
+  ds.train_batch_size=32 \
+  ds.train_micro_batch_size_per_gpu=32 \
+  ds.optimizer.params.eps=1e-16 \
+  ds.optimizer.params.betas=[0.9,0.9] \
+  ds.optimizer.params.weight_decay=0.011 \
+  cf.data.training='{"inputs":"input/valid.src","labels":"label/valid.label"}'
+  ```
+
+
 ## Citation
 
 If you use DenseAttention in research or production, or otherwise find it useful, please cite it as:

--- a/configs/lra/ds_train_dense_attn_pathfinder32.sh
+++ b/configs/lra/ds_train_dense_attn_pathfinder32.sh
@@ -28,7 +28,11 @@ if [ "${1-}" = "--resume" ]; then
     LOAD_EPOCH=""
   fi
 
-  [ $# -ge 1 ] && [ "$1" != "--override" ] || { echo "Usage: $0 --resume [EPOCH|last] JOB_NAME"; exit 1; }
+  [ $# -ge 1 ] && [ "$1" != "--override" ] || {
+    echo "Usage: $0 --resume [EPOCH|last] JOB_NAME"
+    echo "   or: $0 --resume [EPOCH|last] JOB_NAME --override cf.key=value ds.key=value ..."
+    exit 1
+  }
   SUBDIR=$1; shift
 
   if [ "${1-}" = "--override" ]; then

--- a/configs/lra/ds_train_dense_attn_pathfinder32.sh
+++ b/configs/lra/ds_train_dense_attn_pathfinder32.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+params=""
+if [ $# -ne 0 ]; then
+    params="$*"
+fi
+
 base_dir=`pwd`
 
 SEED=${SEED:-100}
@@ -70,4 +75,5 @@ NCCL_TREE_THRESHOLD=0 deepspeed --include localhost:"$NODE" --master_port "$MAST
 --load_training_checkpoint $CHECKPOINT_BASE_PATH \
 --load_checkpoint_id $CHECKPOINT_EPOCH_NAME \
 --project_name "lra-pathfinder-32" \
+--override $params \
 &> ${JOB_NAME}.log

--- a/configs/lra/ds_train_dense_attn_pathfinder32.sh
+++ b/configs/lra/ds_train_dense_attn_pathfinder32.sh
@@ -28,7 +28,7 @@ if [ "${1-}" = "--resume" ]; then
     LOAD_EPOCH=""
   fi
 
-  [ $# -ge 1 ] || { echo "Usage: $0 --resume [EPOCH|last] JOB_NAME"; exit 1; }
+  [ $# -ge 1 ] && [ "$1" != "--override" ] || { echo "Usage: $0 --resume [EPOCH|last] JOB_NAME"; exit 1; }
   SUBDIR=$1; shift
 
   if [ "${1-}" = "--override" ]; then

--- a/deepspeed_train.py
+++ b/deepspeed_train.py
@@ -583,9 +583,9 @@ def construct_arguments():
     args.logger = logger
     config = json.load(open(args.config_file, 'r', encoding='utf-8'))
     args.config = config
-    # Overriding parameters in configs
-    if args.override:
-        override_configs(args)
+    args.deepspeed_config = json.load(
+        open(args.deepspeed_config, 'r', encoding='utf-8'))    
+
     if args.model_config_file and args.model_config_file != args.config_file:
         model_config = json.load(
             open(args.model_config_file, 'r', encoding='utf-8')
@@ -601,8 +601,12 @@ def construct_arguments():
             open(args.train_config_file, 'r', encoding='utf-8')
         )
         args.config["training"] = train_config["training"]
+    
+    # Overriding parameters in configs
+    if args.override:
+        override_configs(args)
+    
     args.task = TaskRegistry.get_task(args.task_type)
-
     args.job_name = config['name'] if args.job_name is None else args.job_name
     print("Running Config File: ", args.job_name)
     # Setting the distributed variables

--- a/deepspeed_train.py
+++ b/deepspeed_train.py
@@ -16,7 +16,7 @@ from tqdm import tqdm
 
 from src.model_config import ModelConfig
 from utils.tasks import TaskRegistry
-from train_arguments import get_argument_parser
+from train_arguments import get_argument_parser, override_configs
 from utils.logger import Logger
 from utils.optimization import warmup_exp_decay_exp, cosine_poly_warmup_decay
 from train_utils import is_time_to_exit, master_process, TensorBoardWriter, WandBWriter
@@ -577,7 +577,9 @@ def get_arguments():
 
 def construct_arguments():
     args = get_arguments()
-
+    # Overriding parameters in configs
+    if args.override:
+        override_configs(args)
     # Prepare Logger
     logger = Logger(cuda=torch.cuda.is_available() and not args.no_cuda)
     args.logger = logger

--- a/deepspeed_train.py
+++ b/deepspeed_train.py
@@ -578,14 +578,14 @@ def get_arguments():
 
 def construct_arguments():
     args = get_arguments()
-    # Overriding parameters in configs
-    if args.override:
-        override_configs(args)
     # Prepare Logger
     logger = Logger(cuda=torch.cuda.is_available() and not args.no_cuda)
     args.logger = logger
     config = json.load(open(args.config_file, 'r', encoding='utf-8'))
     args.config = config
+    # Overriding parameters in configs
+    if args.override:
+        override_configs(args)
     if args.model_config_file and args.model_config_file != args.config_file:
         model_config = json.load(
             open(args.model_config_file, 'r', encoding='utf-8')
@@ -633,8 +633,8 @@ def construct_arguments():
 
 def prepare_optimizer_parameters(args, model):
     config = args.config
-    deepspeed_config = json.load(
-        open(args.deepspeed_config, 'r', encoding='utf-8'))
+    # deepspeed_config = json.load(
+    #     open(args.deepspeed_config, 'r', encoding='utf-8'))
     params_to_optimize = list(model.named_parameters())
     #params_to_optimize = [n for n in params_to_optimize if #'pooler' not in n[0] and
     #                   'embeddings' not in n[0] and 'layer' not in n[0]]

--- a/train_arguments.py
+++ b/train_arguments.py
@@ -446,7 +446,7 @@ def parse_value(val: str):
     - bool:       "true", "false"
     - list:       "[0.9, 0.9]"
     - dict:       '{"inputs":"input/train.src","labels":"label/train.label"}'
-    - str:        "\"input/train.src\""
+    - str:        "\"input/train.src\"", "input/train.src"
 
     Examples:
         parse_value("1")                                → 1 (int)
@@ -460,7 +460,7 @@ def parse_value(val: str):
                                                         "labels": "label/train.label"} (dict)
 
     Notes:
-    - String values must be wrapped in double quotes: "\"text\""
+    - String values can be written as: "text" or text (no need for escape sequences).
     - For dictionaries, use single quotes around the full JSON object.
     """
     try:

--- a/train_arguments.py
+++ b/train_arguments.py
@@ -436,7 +436,32 @@ def set_nested_checked(config_dict: dict, key_path: str, value):
     print(f"Set {key_path} = {value}")
     
 def parse_value(val: str):
-    """Parse a string value into a JSON type if possible, otherwise return as string.
+    """
+    Parses a string into the appropriate JSON-compatible type.
+    If parsing fails, returns the original string.
+
+    Supported types:
+    - int:        "1", "32"
+    - float:      "0.011", "1e-16"
+    - bool:       "true", "false"
+    - list:       "[0.9, 0.9]"
+    - dict:       '{"inputs":"input/train.src","labels":"label/train.label"}'
+    - str:        "\"input/train.src\""
+
+    Examples:
+        parse_value("1")                                → 1 (int)
+        parse_value("false")                            → False (bool)
+        parse_value("1e-16")                            → 1e-16 (float)
+        parse_value("[0.9, 0.9]")                       → [0.9, 0.9] (list)
+        parse_value("\"input/train.src\"")              → "input/train.src" (str, JSON string)
+        parse_value("input/train.src")                  → "input/train.src" (raw string)
+        parse_value('{"inputs":"input/train.src","labels":"label/train.label"}')
+                                                        → {"inputs": "input/train.src",
+                                                        "labels": "label/train.label"} (dict)
+
+    Notes:
+    - String values must be wrapped in double quotes: "\"text\""
+    - For dictionaries, use single quotes around the full JSON object.
     """
     try:
         return json.loads(val)

--- a/train_arguments.py
+++ b/train_arguments.py
@@ -395,7 +395,13 @@ def get_argument_parser():
 
     return parser
 
-def parse_override_string(config_paths: dict, override: str):
+
+"""
+Configuration override implementation.
+Inspired by the implementation in the flame project:
+https://github.com/fla-org/flame
+"""
+def parse_override_string(override: str):
     """Parse a single override string in the format 'cf.key=value' or 'ds.key=value'.
     """
     first_dot = override.find('.')
@@ -408,7 +414,7 @@ def parse_override_string(config_paths: dict, override: str):
     key_path = override[first_dot + 1:end_eq]
     value = override[end_eq + 1:]
     
-    print(f"Parsed override: cfg_name={config_paths[cfg_name]}, key_path={key_path}, value={value}")
+    print(f"Parsed override: key_path={key_path}, value={value}")
     return (cfg_name, key_path, value)
 
 def set_nested_checked(config_dict: dict, key_path: str, value):
@@ -449,21 +455,13 @@ def apply_overrides(configs: dict[str, dict], overrides: list[tuple[str, str, st
 def override_configs(args):
     """Load, apply overrides, and save configuration files based on CLI arguments.
     """
-    config_paths = {
-        "cf": args.config_file,
+    configs = {
+        "cf": args.config,
         "ds": args.deepspeed_config
     }
-    configs = {}
     
-    for name, path in config_paths.items():
-        with open(path, 'r', encoding='utf-8') as f:
-            configs[name] = json.load(f)
-            print("Loaded config '{name}' from {path}")
-
-    overrides = [parse_override_string(config_paths, ovr) for ovr in args.override]
+    overrides = [parse_override_string(ovr) for ovr in args.override]
     apply_overrides(configs, overrides)
-    args.config = configs['cf']
-    args.deepspeed_config = configs['ds']
     print("Args updated: args.config and args.deepspeed_config now hold dicts")
 
     return args


### PR DESCRIPTION
Support for config overrides during script execution has been added. Overrides are specified in the format **cf.key=value** or **ds.key=value** after the script name.
For example:
**ds_train_dense_attn_pathfinder32.sh --override cf.model_config.num_attention_heads=1 cf.model_config.local_attention=false ds.train_batch_size=32 cf.data.validation.inputs="input/train.src".**

The implementation is based on the **--override** flag and further processing in train_arguments.py, which includes the functions **parse_override_string()**, **apply_overrides()**, **set_nested_checked()**, **parse_value()**, and **save_configs()**.

These functions provide safe parsing of keys in the format **cf.key=value** or **ds.key=value**, key validation, logging of all changes, and saving the updated configurations.