### PR TITLE
Improve functionality for linear attention variants and for power transformers in particular.

### DIFF
--- a/src/other_models/attention_kernels.py
+++ b/src/other_models/attention_kernels.py
@@ -478,7 +478,7 @@ class PowerAttention(LinearAttention):
         if self.p < 2 or self.p > 4 or not isinstance(self.p, int):
             raise ValueError(f"Integer powers greater than 1 are currently "
                              f"supported, but you provided {self.p}.")
-        self.feature_map_train = SymPowFastTraining(config, self.p)
+        self.feature_map_train = TensorPowerEmbedding(config, self.p)
         self.feature_map_infer = SymmetricPowerEmbedding(config, self.p)
         self.feature_map = None
         d = config.hidden_size // config.num_attention_heads

--- a/src/other_models/attention_kernels.py
+++ b/src/other_models/attention_kernels.py
@@ -188,9 +188,15 @@ class TensorPowerEmbedding(nn.Module):
     def __init__(self, config, p: int):
         super().__init__()
         self.p = p
+        if config.scaling_d_factor:
+            self.scaling_d_factor = self.d ** ((-1 + 1/p) / 2)
+        else:
+            self.scaling_d_factor = None
         # self.norm_factor = math.pow(config.hidden_size // config.num_attention_heads, self.p / 4.0)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.scaling_d_factor:
+            x *= self.scaling_d_factor
         expanded_x = x
         
         for _ in range(self.p - 1):

--- a/src/other_models/attention_kernels.py
+++ b/src/other_models/attention_kernels.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 from itertools import combinations_with_replacement, product
 
-from src.activations import UncenteredFixedLayerNorm, StandardLayerNorm
+from src.activations import Activation2Class
 from src.positional_embeddings import RelPEBase
 
 
@@ -308,6 +308,10 @@ class LinearAttention(nn.Module):
             self.forward_linear = self._forward_linear_no_norm
             self.forward_quadratic = self._forward_quadratic_no_norm
             self.forward_causal = self._forward_causal_no_norm
+        if config.no_reweight_post_norm:
+            d_head = config.hidden_size // config.num_attention_heads
+            self.post_norm = Activation2Class[
+                config.no_reweight_post_norm](d_head)
         transform = Transform2Func[config.feature_map]
         self.feature_map = transform(config)
         self.apply_relpe_after = config.apply_relpe_after
@@ -395,6 +399,8 @@ class LinearAttention(nn.Module):
         # Batch, *, HeadDim, HeadDim
         attention = torch.matmul(queries, context)
         # Batch, *, SeqLen, HeadDim
+        if self.post_norm:
+            attention = self.post_norm(attention)
         return attention
 
     def _forward_quadratic_no_norm(
@@ -406,6 +412,8 @@ class LinearAttention(nn.Module):
         # Batch, *, SeqLen, SeqLen
         attention = torch.matmul(scores, values)
         # Batch, *, SeqLen, HeadDim
+        if self.post_norm:
+            attention = self.post_norm(attention)
         return attention
 
     def _forward_causal(self, queries: torch.Tensor,
@@ -442,6 +450,8 @@ class LinearAttention(nn.Module):
         # Batch, *, SeqLen, SeqLen
         attention = torch.matmul(scores, values)
         # Batch, *, SeqLen, HeadDim
+        if self.post_norm:
+            attention = self.post_norm(attention)
         return attention
 
 
@@ -482,8 +492,6 @@ class PowerAttention(LinearAttention):
         # embeddings in linear mode). Or equivalently, N vs d' + d^p-1.
         self.lin_thr = num_monomials + d ** (self.p - 1)
 
-        if self.no_reweight:
-            self.post_attn_norm = StandardLayerNorm(d)
 
     def forward(self, queries: torch.Tensor,
                 keys: torch.Tensor, values: torch.Tensor,
@@ -510,14 +518,6 @@ class PowerAttention(LinearAttention):
             keys = feature_map(keys)
             return self.forward_linear(queries, keys, values, attn_mask, dropout_p)
 
-    def _forward_linear_no_norm(
-            self, queries: torch.Tensor, keys: torch.Tensor,
-            values: torch.Tensor, attn_mask: torch.Tensor, dropout: float
-    ):
-        attention = super()._forward_linear_no_norm(queries, keys, values,
-                                                    attn_mask, dropout)
-        return self.post_attn_norm(attention)
-
     def _forward_quadratic(self, queries: torch.Tensor,
                            keys: torch.Tensor, values: torch.Tensor,
                            attn_mask: torch.Tensor, dropout: float):
@@ -541,7 +541,9 @@ class PowerAttention(LinearAttention):
         # Batch, *, SeqLen, SeqLen
         attention = torch.matmul(scores, values)
         # Batch, *, SeqLen, HeadDim
-        return self.post_attn_norm(attention)
+        if self.post_norm:
+            attention = self.post_norm(attention)
+        return attention
 
     def _forward_causal(self, queries: torch.Tensor,
                         keys: torch.Tensor, values: torch.Tensor,
@@ -577,5 +579,7 @@ class PowerAttention(LinearAttention):
         # Batch, *, SeqLen, SeqLen
         attention = torch.matmul(scores, values)
         # Batch, *, SeqLen, HeadDim
-        return self.post_attn_norm(attention)
+        if self.post_norm:
+            attention = self.post_norm(attention)
+        return attention
 

--- a/src/other_models/attention_kernels.py
+++ b/src/other_models/attention_kernels.py
@@ -2,7 +2,9 @@ import math
 import torch
 import torch.nn as nn
 from torch.nn.attention.flex_attention import create_block_mask, flex_attention
-from itertools import combinations_with_replacement
+from itertools import combinations_with_replacement, product
+
+from src.activations import UncenteredFixedLayerNorm, StandardLayerNorm
 from src.positional_embeddings import RelPEBase
 
 
@@ -53,26 +55,27 @@ class SymmetricPowerEmbedding(nn.Module):
         self.p = p
         self.d = config.hidden_size // config.num_attention_heads
         # self.norm_factor = math.pow(self.d, self.p / 4.0)
-        
-        self.register_buffer('indices_tensor', None, persistent=False)
-        self.register_buffer('coeffs', None, persistent=False)
-
         # generates list of non-decreasing multiindices
         # num_monomials = C(d+p-1, p)
         # indices: num_monomials, p
         indices = list(combinations_with_replacement(range(self.d), self.p))
-        self.indices_tensor = torch.tensor(indices, dtype=torch.long)
+        self.num_monomials = len(indices)
+        if config.scaling_d_factor:
+            self.scaling_d_factor = self.d ** ((p - 1) / 2)
+        else:
+            self.scaling_d_factor = 1
+        indices_tensor = torch.tensor(indices, dtype=torch.long)
 
         # given a multiindex, counts how many times each index appears
         counts = torch.zeros(len(indices), self.d, dtype=torch.float32)
         # counts: num_monomials, d
-        ones = torch.ones_like(self.indices_tensor, dtype=torch.float32)
+        ones = torch.ones_like(indices_tensor, dtype=torch.float32)
         # ones: num_monomials, p
         
         # For each monomial (row), adds 1 to counts[m, j] whenever variable j
         # appears in indices_tensor[m]. Records how many times each variable
         # occurs in each monomial.
-        counts.scatter_add_(dim=1, index=self.indices_tensor, src=ones)
+        counts.scatter_add_(dim=1, index=indices_tensor, src=ones)
 
         # computes multinomial coefficient
         # lgamma(n+1) = ln(Г(n+1)) = ln(n!)
@@ -82,22 +85,91 @@ class SymmetricPowerEmbedding(nn.Module):
         log_numerator = math.lgamma(self.p + 1)
         log_denom = torch.lgamma(counts + 1).sum(dim=1)
         log_coeffs = 0.5 * (log_numerator - log_denom)
-        
+        coeffs = torch.exp(log_coeffs) / self.scaling_d_factor
         # coeffs: num_monomials
-        coeffs = torch.exp(log_coeffs)
-        self.coeffs = coeffs
+
+        # We transpose `indices` to get a fast, contiguous view of rows in forward.
+        self.register_buffer('indices', indices_tensor.t().contiguous(),
+                             persistent=False) # shape: p, num_monomials
+        self.register_buffer('coeffs', coeffs, persistent=False)
 
     def forward(self, x: torch.Tensor):
-        # Computes the product over the last dimension (monomials of degree p)
-        # Select coordinates according to multi-indices
-        # Example: if index=(0,2), we take x[...,0] and x[...,2]
-        selected = x[..., self.indices_tensor]
-        # selected: Batch, ..., SeqLen, num_monomials, p
-        
-        monomials = selected.prod(dim=-1)
-        # monomials: Batch, ..., SeqLen, num_monomials
+        # Create a tensor of the final flattened form and, for each of p factors,
+        # multiply it with relevant x_{indices_i} values, i \in [0, ..., p-1].
+        result = torch.ones(size=x.size()[:-1] + [self.num_monomials],
+                            dtype=x.dtype, device=x.device)
 
-        return (monomials * self.coeffs)
+        for i in range(self.p):
+            indices = self.indices[i]
+            factors = torch.index_select(x, -1, indices)
+            result.mul_(factors)
+        return result * self.coeffs
+
+
+
+class SymPowFastTraining(nn.Module):
+    """ A version of `SymmetricPowerEmbedding`, faster in training but slower
+    at inference."""
+
+    def __init__(self, config, p: int):
+        import numpy as np
+        from scipy.special import factorial
+        super().__init__()
+        self.p = p
+        self.d = config.hidden_size // config.num_attention_heads
+        num_monomials = math.comb(self.d + p - 1, p)
+        if config.scaling_d_factor:
+            self.scaling_d_factor = self.d ** ((p - 1) / 2)
+        else:
+            self.scaling_d_factor = 1
+
+        all_terms = list(product(range(self.d), repeat=p))
+        # all_terms' shape: d^p, p
+        # Find only non-decreasing sequences in all terms. These are mutually
+        # unique, and all remaining terms are just their permutations.
+        non_dec_terms = (np.diff(all_terms, axis=-1) >= 0).all(axis=-1)
+        # non_dec_terms: d^p
+        unique_inds = np.arange(self.d ** p)[non_dec_terms]
+        assert len(unique_inds) == num_monomials
+        # unique_inds: num_monomials = C(d+p-1, p)
+        unique_items = np.array(all_terms)[non_dec_terms]
+        # unique_items: num_monomials, p
+
+        # As all numbers in unique_items are in non-decreasing order, we can
+        # produce cumulative counts of unique numbers in a term, starting
+        # from 0. In every row, each distinct number gets replaced by its
+        # label (cumulative count). E.g., d=5, p=4, an item: 1 2 2 4,
+        # corresponding labels: 0 1 1 2
+        labels = np.zeros_like(unique_items)
+        labels[:, 1:] = ((unique_items[:, 1:] != unique_items[:, :-1])
+                         .cumsum(axis=1))
+        # This adds offsets to each row so labels don't repeat across rows
+        labels += p * np.arange(num_monomials)[:, None] # shape: num_monomials, p
+        # Finally produce counts of unique numbers across monomials (rows):
+        counts = (np.bincount(labels.ravel(), minlength=num_monomials * p)
+                  .reshape(num_monomials, p)) # shape: num_monomials, p
+        # Find multinomial coefficients for all monomials. coeffs[m] =
+        # p! / (count_1! * count_2! * ...)
+        coeffs = factorial(p) / factorial(counts).prod(axis=-1)
+        assert coeffs.sum() == self.d**p
+        # Square root because coeffs apply both to queries and keys.
+        coeffs = np.sqrt(coeffs) / self.scaling_d_factor # shape: num_monomials
+
+        # IntTensor instead of LongTensor because very large d**p are impractical.
+        self.register_buffer('indices', torch.IntTensor(unique_inds),
+                             persistent=False)
+        self.register_buffer('coeffs', torch.Tensor(coeffs), persistent=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Full tensor power expansion
+        expanded_x = x
+        for _ in range(self.p - 1):
+            x = x.unsqueeze(-2)
+            expanded_x = expanded_x.unsqueeze(-1) * x
+        expanded_x = expanded_x.flatten(start_dim=-self.p)
+        # expanded_x: ..., d**p
+        # Choose only unique terms of expansion and multiply by coeffs
+        return torch.index_select(expanded_x, -1, self.indices) * self.coeffs
 
 
 class TensorPowerEmbedding(nn.Module):
@@ -167,6 +239,9 @@ Transform2Func = {
     "sym_power_2": lambda config: SymmetricPowerEmbedding(config, p=2),
     "sym_power_3": lambda config: SymmetricPowerEmbedding(config, p=2),
     "sym_power_4": lambda config: SymmetricPowerEmbedding(config, p=4),
+    "sympow_train_2": lambda config: SymPowFastTraining(config, p=2),
+    "sympow_train_3": lambda config: SymPowFastTraining(config, p=3),
+    "sympow_train_4": lambda config: SymPowFastTraining(config, p=4),
     "power_2": lambda config: TensorPowerEmbedding(config, p=2),
     "power_3": lambda config: TensorPowerEmbedding(config, p=3),
     "power_4": lambda config: TensorPowerEmbedding(config, p=4),
@@ -221,28 +296,35 @@ class SlidingWindowAttention(nn.Module):
 
 
 class LinearAttention(nn.Module):
+    """General Linear Attention implementation for an arbitrary feature map."""
     def __init__(self, config, eps=1e-6):
         super(LinearAttention, self).__init__()
         self.no_reweight = config.no_reweight
         self.forward_linear = self._forward_linear
         self.forward_quadratic = self._forward_quadratic
+        self.forward_causal = self._forward_causal
         self.eps = eps
         if self.no_reweight:
             self.forward_linear = self._forward_linear_no_norm
-            self.forward_quadratic = self._forward_quadratic_no_norm  
+            self.forward_quadratic = self._forward_quadratic_no_norm
+            self.forward_causal = self._forward_causal_no_norm
         transform = Transform2Func[config.feature_map]
         self.feature_map = transform(config)
         self.apply_relpe_after = config.apply_relpe_after
         self.local = False
 
+        self.seq_len = None
+        self.causal_mask = None
+
     def forward(self, queries: torch.Tensor,
                 keys: torch.Tensor, values: torch.Tensor,
-                attn_mask: torch.Tensor, dropout_p: float, causal: bool, rope_cache: RelPEBase):
-        # TODO: implement causal linear attention
-        queries = self.feature_map(queries)
+                attn_mask: torch.Tensor, dropout_p: float, causal: bool,
+                rope_cache: RelPEBase = None):
+        # TODO: implement chunk-wise parallel causal linear attention
         queries = nn.functional.dropout(queries,p=dropout_p)
-        keys = self.feature_map(keys)
+        queries = self.feature_map(queries)
         keys = nn.functional.dropout(keys,p=dropout_p)
+        keys = self.feature_map(keys)
         shape = queries.shape
         n, d = shape[-2], shape[-1]
         if self.apply_relpe_after:
@@ -252,7 +334,8 @@ class LinearAttention(nn.Module):
           else:
             queries = rope_cache.apply_relpe(queries)
             keys = rope_cache.apply_relpe(keys)
-
+        if causal:
+            return self.forward_causal(queries, keys, values, attn_mask, dropout_p)
         if n < d:
             return self.forward_quadratic(queries, keys, values, attn_mask, dropout_p)
         else:
@@ -260,6 +343,18 @@ class LinearAttention(nn.Module):
 
     def set_local_relpe_state(self, use_local=True):
         local = use_local
+
+    def _causal_mask(self, scores: torch.Tensor):
+        n = scores.shape[-1]
+        if self.seq_len != n or self.causal_mask is None:
+            device, dtype = scores.device, scores.dtype
+            broadcast_dims = len(scores.shape) - 2
+            mask_shape = [1] * broadcast_dims + [n, n]
+            # Create the mask on CPU and move it to device later, to circumvent
+            # the issue https://github.com/pytorch/pytorch/issues/136611.
+            mask = torch.ones(size=mask_shape, dtype=dtype).tril_().to(device)
+            self.causal_mask = mask
+        return self.causal_mask
 
     def _forward_linear(self, queries: torch.Tensor,
                         keys: torch.Tensor, values: torch.Tensor,
@@ -283,11 +378,9 @@ class LinearAttention(nn.Module):
         # q, k, v: Batch, *, SeqLen, HeadDim
         scores = torch.matmul(queries, keys.transpose(-2, -1))
         # Batch, *, SeqLen, SeqLen
-        normalizer = keys.sum(dim=-2, keepdim=True)
-        # Batch, *, 1, HeadDim
-        normalizer = normalizer.transpose(-2, -1)
-        # Batch, *, HeadDim, 1
-        scores = scores / (torch.matmul(queries, normalizer) + self.eps)
+        normalizer = scores.sum(dim=-1, keepdim=True)
+        # Batch, *, SeqLen, 1
+        scores = scores / (normalizer + self.eps)
         # (Batch, *, SeqLen, SeqLen) / (Batch, *, SeqLen, 1)
         attention = torch.matmul(scores, values)
         # Batch, *, SeqLen, HeadDim
@@ -314,4 +407,175 @@ class LinearAttention(nn.Module):
         attention = torch.matmul(scores, values)
         # Batch, *, SeqLen, HeadDim
         return attention
+
+    def _forward_causal(self, queries: torch.Tensor,
+                        keys: torch.Tensor, values: torch.Tensor,
+                        attn_mask: torch.Tensor, dropout: float):
+        # q, k, v: Batch, *, SeqLen, HeadDim
+        scores = torch.matmul(queries, keys.transpose(-2, -1))
+        # See https://github.com/pytorch/pytorch/issues/136611
+        if scores.shape[-1] <= 16384:
+            scores.tril_()
+        else:
+            mask = torch.ones(scores.size()).tril_()
+            scores = scores * self._causal_mask(scores)
+        # Batch, *, SeqLen, SeqLen
+        normalizer = scores.sum(dim=-1, keepdim=True)
+        # Batch, *, SeqLen, 1
+        scores = scores / (normalizer + self.eps)
+        # (Batch, *, SeqLen, SeqLen) / (Batch, *, SeqLen, 1)
+        attention = torch.matmul(scores, values)
+        # Batch, *, SeqLen, HeadDim
+        return attention
+
+    def _forward_causal_no_norm(self, queries: torch.Tensor,
+                                keys: torch.Tensor, values: torch.Tensor,
+                                attn_mask: torch.Tensor, dropout: float):
+        # q, k, v: Batch, *, SeqLen, HeadDim
+        scores = torch.matmul(queries, keys.transpose(-2, -1))
+        # See https://github.com/pytorch/pytorch/issues/136611
+        if scores.shape[-1] <= 16384:
+            scores.tril_()
+        else:
+            mask = torch.ones(scores.size()).tril_()
+            scores = scores * self._causal_mask(scores)
+        # Batch, *, SeqLen, SeqLen
+        attention = torch.matmul(scores, values)
+        # Batch, *, SeqLen, HeadDim
+        return attention
+
+
+class PowerAttention(LinearAttention):
+    """
+    A standalone implementation of attention based on Power/ Symmetric Power
+    Transformers/ PolySketchFormer (exact variant). Supports quadratic mode
+    computations where it's faster.
+
+    References:
+        Symmetric Power Transformers:
+            https://manifestai.com/articles/symmetric-power-transformers/
+        PolySketchFormer: Fast Transformers via Sketching Polynomial Kernels:
+            https://proceedings.mlr.press/v235/kacham24a.html
+
+    Conceptual differences in relation to papers:
+        – Supports no re-weighing attention scores by their row-wise sums;
+        – Optional scaling_d_factor for prevention of large absolute values;
+        – LayerNorm after attention in no re-weighing case
+
+    """
+    def __init__(self, config, eps=1e-6):
+        super(PowerAttention, self).__init__(config, eps)
+        self.p = config.power
+        if self.p < 2 or self.p > 4 or not isinstance(self.p, int):
+            raise ValueError(f"Integer powers greater than 1 are currently "
+                             f"supported, but you provided {self.p}.")
+        self.feature_map_train = SymPowFastTraining(config, self.p)
+        self.feature_map_infer = SymmetricPowerEmbedding(config, self.p)
+        self.feature_map = None
+        d = config.hidden_size // config.num_attention_heads
+        if config.scaling_d_factor:
+            self.scaling_d_factor = d ** -((self.p - 1) / 2)
+        else:
+            self.scaling_d_factor = None
+        num_monomials = math.comb(d + self.p - 1, self.p) # d'
+        # 2Nd^2 (quadratic mode) vs 2Ndd' + 2Nd^p (compute + construct
+        # embeddings in linear mode). Or equivalently, N vs d' + d^p-1.
+        self.lin_thr = num_monomials + d ** (self.p - 1)
+
+        if self.no_reweight:
+            self.post_attn_norm = StandardLayerNorm(d)
+
+    def forward(self, queries: torch.Tensor,
+                keys: torch.Tensor, values: torch.Tensor,
+                attn_mask: torch.Tensor, dropout_p: float, causal: bool,
+                rope_cache: RelPEBase = None):
+        # TODO: implement chunk-wise parallel causal linear attention
+        queries = nn.functional.dropout(queries, p=dropout_p)
+        keys = nn.functional.dropout(keys, p=dropout_p)
+        if causal:
+            if self.scaling_d_factor:
+                queries = queries * self.scaling_d_factor
+                keys = keys * self.scaling_d_factor
+            return self.forward_causal(queries, keys, values, attn_mask, dropout_p)
+        n = queries.shape[-2]
+        if n < self.lin_thr:
+            if self.scaling_d_factor:
+                queries = queries * self.scaling_d_factor
+                keys = keys * self.scaling_d_factor
+            return self.forward_quadratic(queries, keys, values, attn_mask, dropout_p)
+        else:
+            feature_map = self.feature_map_train if self.training else (
+                self.feature_map_infer)
+            queries = feature_map(queries)
+            keys = feature_map(keys)
+            return self.forward_linear(queries, keys, values, attn_mask, dropout_p)
+
+    def _forward_linear_no_norm(
+            self, queries: torch.Tensor, keys: torch.Tensor,
+            values: torch.Tensor, attn_mask: torch.Tensor, dropout: float
+    ):
+        attention = super()._forward_linear_no_norm(queries, keys, values,
+                                                    attn_mask, dropout)
+        return self.post_attn_norm(attention)
+
+    def _forward_quadratic(self, queries: torch.Tensor,
+                           keys: torch.Tensor, values: torch.Tensor,
+                           attn_mask: torch.Tensor, dropout: float):
+        # q, k, v: Batch, *, SeqLen, HeadDim
+        scores = torch.matmul(queries, keys.transpose(-2, -1)).pow(self.p)
+        # Batch, *, SeqLen, SeqLen
+        normalizer = scores.sum(dim=-1, keepdim=True)
+        # Batch, *, SeqLen, 1
+        scores = scores / (normalizer + self.eps)
+        # (Batch, *, SeqLen, SeqLen) / (Batch, *, SeqLen, 1)
+        attention = torch.matmul(scores, values)
+        # Batch, *, SeqLen, HeadDim
+        return attention
+
+    def _forward_quadratic_no_norm(
+            self, queries: torch.Tensor, keys: torch.Tensor,
+            values: torch.Tensor, attn_mask: torch.Tensor, dropout: float
+    ):
+        # q, k, v: Batch, *, SeqLen, HeadDim
+        scores = torch.matmul(queries, keys.transpose(-2, -1)).pow(self.p)
+        # Batch, *, SeqLen, SeqLen
+        attention = torch.matmul(scores, values)
+        # Batch, *, SeqLen, HeadDim
+        return self.post_attn_norm(attention)
+
+    def _forward_causal(self, queries: torch.Tensor,
+                        keys: torch.Tensor, values: torch.Tensor,
+                        attn_mask: torch.Tensor, dropout: float):
+        # q, k, v: Batch, *, SeqLen, HeadDim
+        scores = torch.matmul(queries, keys.transpose(-2, -1)).pow(self.p)
+        # See https://github.com/pytorch/pytorch/issues/136611
+        if scores.shape[-1] <= 16384:
+            scores.tril_()
+        else:
+            mask = torch.ones(scores.size()).tril_()
+            scores = scores * self._causal_mask(scores)
+        # Batch, *, SeqLen, SeqLen
+        normalizer = scores.sum(dim=-1, keepdim=True)
+        # Batch, *, SeqLen, 1
+        scores = scores / (normalizer + self.eps)
+        # (Batch, *, SeqLen, SeqLen) / (Batch, *, SeqLen, 1)
+        attention = torch.matmul(scores, values)
+        # Batch, *, SeqLen, HeadDim
+        return attention
+
+    def _forward_causal_no_norm(self, queries: torch.Tensor,
+                                keys: torch.Tensor, values: torch.Tensor,
+                                attn_mask: torch.Tensor, dropout: float):
+        # q, k, v: Batch, *, SeqLen, HeadDim
+        scores = torch.matmul(queries, keys.transpose(-2, -1)).pow(self.p)
+        # See https://github.com/pytorch/pytorch/issues/136611
+        if scores.shape[-1] <= 16384:
+            scores.tril_()
+        else:
+            mask = torch.ones(scores.size()).tril_()
+            scores = scores * self._causal_mask(scores)
+        # Batch, *, SeqLen, SeqLen
+        attention = torch.matmul(scores, values)
+        # Batch, *, SeqLen, HeadDim
+        return self.post_attn_norm(attention)
 

--- a/src/other_models/modeling.py
+++ b/src/other_models/modeling.py
@@ -37,6 +37,7 @@ from torch.nn import CrossEntropyLoss
 from src.positional_embeddings import PositionalEmbeddingsTypes, SinusoidalPositionalEncoding, RelPETypeToClass, \
     RelPEType
 from .attention_kernels import SoftmaxAttention, LinearAttention, SlidingWindowAttention, PowerAttention
+from ..activations import Activation2Class
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,7 @@ class TransformerConfig(object):
                  attention_kernel="softmax",
                  feature_map=None,
                  no_reweight=False,
+                 no_reweight_post_norm=None,
                  hidden_act="gelu",
                  embedding_dropout=0,
                  hidden_dropout_prob=0.1,
@@ -100,6 +102,8 @@ class TransformerConfig(object):
                  relpe_type=None,
                  type_vocab_size=2,
                  initializer_range=0.02,
+                 pre_attn_ln_type="default",
+                 post_attn_ln_type="default",
                  causal=False,
                  local_attention=False,
                  window_size=1024,
@@ -131,6 +135,9 @@ class TransformerConfig(object):
                 `BertModel`.
             initializer_range: The sttdev of the truncated_normal_initializer for
                 initializing all weight matrices.
+            pre_attn_ln_type: If not set to "default" (which is `BertLayerNorm`),
+                determines the type of layer norm or activation to use before attention.
+            post_attn_ln_type: Like `pre_attn_ln_type` but for usage before FFN.
             attention_kernel: Mechanism for attention to use. Currently supported:
                 "softmax", "swa", "linear", "power". Power attention is subtype of
                 linear attention, and many options for linear attention also apply.
@@ -138,6 +145,9 @@ class TransformerConfig(object):
                 attentions.
             no_reweight: For linear attentions, if set to true, doesn't scale attention
                 scores by their row-wise sums.
+            no_reweight_post_norm: In case of enabled `no_reweight` option in linear
+                attentions, determines whether and which layer norm to use at the end
+                of attention kernel computation. Defaults to None.
             apply_relpe_after: For linear attentions, determines whether Relative
                 Positional Encoding (RELPE) is applied after the feature map (if true)
                 or before the linear attention kernel (if false).
@@ -162,6 +172,7 @@ class TransformerConfig(object):
             self.attention_kernel = attention_kernel
             self.feature_map = feature_map
             self.no_reweight = no_reweight
+            self.no_reweight_post_norm = no_reweight_post_norm
             self.embedding_dropout = embedding_dropout
             self.hidden_dropout_prob = hidden_dropout_prob
             self.attention_probs_dropout_prob = attention_probs_dropout_prob
@@ -171,6 +182,8 @@ class TransformerConfig(object):
             self.relpe_type = relpe_type
             self.type_vocab_size = type_vocab_size
             self.initializer_range = initializer_range
+            self.pre_attn_ln_type = pre_attn_ln_type
+            self.post_attn_ln_type = post_attn_ln_type
             self.causal = causal
             self.local_attention = local_attention
             self.window_size = window_size
@@ -436,8 +449,10 @@ class BertSelfLocalAttention(BertSelfAttention):
         value_layer = self.transpose_for_local_scores(mixed_value_layer, num_windows)
 
         if not self.apply_relpe_after:
-          query_layer = rope_cache.apply_local_relpe2(query_layer, self.window_size, num_windows)
-          key_layer = rope_cache.apply_local_relpe2(key_layer, self.window_size, num_windows)
+            query_layer = rope_cache.apply_local_relpe2(
+                query_layer, self.window_size, num_windows)
+            key_layer = rope_cache.apply_local_relpe2(
+                key_layer, self.window_size, num_windows)
         # Batch, Seq, Head, SubSeqLen, HeadDim
         #if torch.all(attention_mask == 0):
         attention_mask = None
@@ -589,9 +604,15 @@ class BertLayer(nn.Module):
         self.attention = BertAttention(config)
         self.PreAttentionLayerNorm = BertLayerNorm(config.hidden_size,
                                                    eps=1e-12)
+        if config.pre_attn_ln_type != "default":
+            self.PreAttentionLayerNorm = Activation2Class[
+                config.pre_attn_ln_type](config.hidden_size, eps=1e-12)
         #self.MidAttentionLayerNorm = BertLayerNorm(config.hidden_size, eps = 1e-12)
         self.PostAttentionLayerNorm = BertLayerNorm(config.hidden_size,
                                                     eps=1e-12)
+        if config.post_attn_ln_type != "default":
+            self.PostAttentionLayerNorm = Activation2Class[
+                config.post_attn_ln_type](config.hidden_size, eps=1e-12)
         self.intermediate = BertIntermediate(config)
         self.output = BertOutput(config)
         if config.hidden_act == "swiglu":

--- a/src/other_models/modeling.py
+++ b/src/other_models/modeling.py
@@ -36,7 +36,7 @@ from torch.nn import CrossEntropyLoss
 
 from src.positional_embeddings import PositionalEmbeddingsTypes, SinusoidalPositionalEncoding, RelPETypeToClass, \
     RelPEType
-from .attention_kernels import SoftmaxAttention, LinearAttention, SlidingWindowAttention
+from .attention_kernels import SoftmaxAttention, LinearAttention, SlidingWindowAttention, PowerAttention
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +104,8 @@ class TransformerConfig(object):
                  local_attention=False,
                  window_size=1024,
                  apply_relpe_after=False,
+                 power=2,
+                 scaling_d_factor=False,
                  **kwargs):
         """Constructs ModelConfig.
 
@@ -129,8 +131,20 @@ class TransformerConfig(object):
                 `BertModel`.
             initializer_range: The sttdev of the truncated_normal_initializer for
                 initializing all weight matrices.
-            apply_relpe_after: Whether Relative Positional Encoding (RELPE) is applied after the feature map (if true)
-             or before the linear attention kernel (if false).
+            attention_kernel: Mechanism for attention to use. Currently supported:
+                "softmax", "swa", "linear", "power". Power attention is subtype of
+                linear attention, and many options for linear attention also apply.
+            feature_map: A feature map transform (\phi) for queries and keys in linear
+                attentions.
+            no_reweight: For linear attentions, if set to true, doesn't scale attention
+                scores by their row-wise sums.
+            apply_relpe_after: For linear attentions, determines whether Relative
+                Positional Encoding (RELPE) is applied after the feature map (if true)
+                or before the linear attention kernel (if false).
+            power: For Power Attention, determines the power (p).
+            scaling_d_factor: For Power Attention, determines whether to scale q,k by a
+                predetermined scaling factor depending on d for additional numerical
+                stability.
         """
         if isinstance(vocab_size_or_config_json_file, str):
             with open(vocab_size_or_config_json_file, "r",
@@ -161,6 +175,8 @@ class TransformerConfig(object):
             self.local_attention = local_attention
             self.window_size = window_size
             self.apply_relpe_after = apply_relpe_after
+            self.power = power
+            self.scaling_d_factor = scaling_d_factor
         else:
             raise ValueError(
                 "First argument must be either a vocabulary size (int)"
@@ -289,6 +305,8 @@ class BertSelfAttention(nn.Module):
             self.attention_kernel = SlidingWindowAttention(config)
         elif config.attention_kernel == "linear":
             self.attention_kernel = LinearAttention(config)
+        elif config.attention_kernel == "power":
+            self.attention_kernel = PowerAttention(config)
         else:
             raise NotImplementedError(
                 f"Attention kernel for {config.attention_kernel} is not "


### PR DESCRIPTION
Changelist:

1) Speed up Symmetric Power feature map up to 3.5x for training and by 10% for inference in linear mode by augmenting `SymmetricPowerEmbedding` and developing `SymPowFastTraining` classes; 
2) Add standalone Power-like Attention implementation which supports both quadratic and linear modes; 
3) Move drop-out to immediately before feature maps in `LinearAttention` class; 
4) Add causal mode for `LinearAttention` class; 
5) Improve re-weighing theoretical speed for quadratic methods of `LinearAttention` class; 
6) Add optional `scaling_d_factor` for prevention of large absolute values; 
7) Add optional `post_ln` layer norm for `no_reweight=True` linear attention kernels, which can be chosen to be any activation or layer norm.
8) Make `PreAttentionLayerNorm` and `PostAttentionLayerNorm` configurable for Transformer-based models.
9) Add new parameters in `TransformerConfig` and document them as well as some exisiting ones