### PR TITLE
Bugfixes/issue 41

### DIFF
--- a/deepspeed_train.py
+++ b/deepspeed_train.py
@@ -905,7 +905,9 @@ def run(args, model, optimizer, start_epoch):
                     )
                     success = True
                 except Exception as ex:
-                    print(ex)
+                    TIME_TO_SLEEP = 60
+                    print(ex, f" Retrying in {TIME_TO_SLEEP} s.")
+                    time.sleep(TIME_TO_SLEEP)
             manage_checkpoints(args.saved_model_path, args)
                     
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ zstandard
 nltk
 tensorboardX==2.6.1
 clearml
+pytest

--- a/src/dense_attention.py
+++ b/src/dense_attention.py
@@ -140,10 +140,16 @@ class DenseAttention(nn.Module):
                                  f"{self.relpe_scheme} conform to acceptable codes "
                                  f"{relpe_keys}.")
 
+        # Set RelPE functions which are used in `_forward_chunked`. They can be
+        # local, global or dummy, depending on `local_relpe` and `relpe_scheme`
+        # config settings.
         self.pre_apply_relpe = self._apply_dummy_relpe
         self.apply_q_relpe = self._apply_dummy_relpe
         self.apply_k_relpe = self._apply_dummy_relpe
         self.apply_v_relpe = self._apply_dummy_relpe
+        # Set RelPE functions which are used in `forward_global`. They are
+        # guaranteed to be either global or dummy, depending on the
+        # `relpe_scheme`.
         self.pre_apply_global_relpe = self._apply_dummy_relpe
         self.apply_q_global_relpe = self._apply_dummy_relpe
         self.apply_k_global_relpe = self._apply_dummy_relpe

--- a/src/dense_attention.py
+++ b/src/dense_attention.py
@@ -442,7 +442,7 @@ class DenseAttention(nn.Module):
         last_chunk =  seq_len - chunk_size * num_chunks
         if last_chunk != 0:
             remainder_dims = list(size)
-            remainder_dims[1] = last_chunk
+            remainder_dims[1] = chunk_size - last_chunk
             remainder = torch.zeros(
                 size=remainder_dims, device=hidden_states.device,
                 dtype=hidden_states.dtype
@@ -491,7 +491,7 @@ class DenseAttention(nn.Module):
         output = self.permute_dims_f(attention)
         # output: (Batch, Chunk, ChunkLen, EmbedDim) or
         # (Batch, Chunk, ChunkLen, Head, HeadDim)
-        output = output.reshape(size[0], seq_len + last_chunk, size[2])
+        output = output.reshape(size[0], -1, size[2])
         output = output[:, :seq_len, :]
         # output: Batch, SeqLen, EmbedDim
         return output

--- a/src/modeling.py
+++ b/src/modeling.py
@@ -161,8 +161,9 @@ class DANetEncoder(nn.Module):
             self.final_transform_fn = lambda x: x
 
         self.rope_cache = RelPETypeToClass[self.relpe_type](
-            config.max_position_embeddings, #args.max_seq_length
-            config.hidden_size // config.num_attention_heads,
+            seq_len=config.max_position_embeddings,
+            n_elem=config.hidden_size // config.num_attention_heads,
+            sep_head_dim=False,
             num_heads=config.num_attention_heads
         )
         self.local_scheme = config.local_scheme.split("_")

--- a/src/other_models/modeling.py
+++ b/src/other_models/modeling.py
@@ -651,9 +651,9 @@ class BertEncoder(nn.Module):
         else:
             self. relpe_type = RelPEType.DUMMY
         self.rope_cache = RelPETypeToClass[self.relpe_type](
-            config.max_position_embeddings, #args.max_seq_length
-            config.hidden_size // config.num_attention_heads,
-            #num_heads=config.num_attention_heads
+            seq_len=config.max_position_embeddings,
+            n_elem=config.hidden_size // config.num_attention_heads,
+            sep_head_dim=True
         )
 
         layer = BertLayer(config)

--- a/src/positional_embeddings.py
+++ b/src/positional_embeddings.py
@@ -115,6 +115,7 @@ class RoPE(RelPEBase):
         cache_sin = torch.sin(angles).unsqueeze(0)
         # cache: bs (1), seqlen, head embed dim
         if sep_head_dim:
+            self.apply_local_relpe = self.apply_local_relpe_sep
             cache_cos = cache_cos.unsqueeze(1)
             cache_sin = cache_sin.unsqueeze(1)
             # cache: bs (1), headdim (1), seqlen, head embed dim
@@ -122,6 +123,7 @@ class RoPE(RelPEBase):
             if num_heads is None:
                 raise ValueError("If head and embedding dimensions are not "
                                  "separated, `num_heads` should be provided.")
+            self.apply_local_relpe = self.apply_local_relpe_fused
             cache_cos = cache_cos.repeat(1, 1, num_heads)
             cache_sin = cache_sin.repeat(1, 1, num_heads)
             # cache: bs (1), seqlen, head embed dim * num heads
@@ -163,16 +165,23 @@ class RoPE(RelPEBase):
         x = x * cache_cos + self.rotate_half(x) * cache_sin
         return x.to(pdtype)
 
-    def apply_local_relpe(self, x: torch.Tensor, window_size, num_windows):
+    def apply_local_relpe_fused(self, x: torch.Tensor, window_size, num_windows):
         """Applies RoPE in a way that treats local attention windows as
         independent sequences. It's assumed that input `x` is of form
-        (bs, num_windows * window_size, num_heads * head_dim) or
-        (bs, num_heads, num_windows * window_size, head_dim), depending on init."""
+        (bs, num_windows * window_size, num_heads * head_dim)."""
         cache_cos = self.cache_cos[..., :window_size, :].repeat(1, num_windows, 1)
         cache_sin = self.cache_sin[..., :window_size, :].repeat(1, num_windows, 1)
         pdtype = x.dtype
-        # First half of the tensor [x1, x2] takes form x1 * cos - x2 * sin
-        # Second half is x1 * cos + x2 * sin
+        x = x * cache_cos + self.rotate_half(x) * cache_sin
+        return x.to(pdtype)
+
+    def apply_local_relpe_sep(self, x: torch.Tensor, window_size, num_windows):
+        """Applies RoPE in a way that treats local attention windows as
+        independent sequences. It's assumed that input `x` is of form
+        (bs, num_heads, num_windows * window_size, head_dim)."""
+        cache_cos = self.cache_cos[..., :window_size, :].repeat(1, 1, num_windows, 1)
+        cache_sin = self.cache_sin[..., :window_size, :].repeat(1, 1, num_windows, 1)
+        pdtype = x.dtype
         x = x * cache_cos + self.rotate_half(x) * cache_sin
         return x.to(pdtype)
 
@@ -232,12 +241,14 @@ class TrigRelPEBase(RelPEBase):
         angles: torch.Tensor = torch.outer(torch.arange(seq_len), theta)
         cache = self.trig_transform(angles).unsqueeze(0)
         if sep_head_dim:
+            self.apply_local_relpe = self.apply_local_relpe_sep
             cache = cache.unsqueeze(1)
             # cache: bs (1), headdim (1), seqlen, head embed dim
         else:
             if num_heads is None:
                 raise ValueError("If head and embedding dimensions are not "
                                  "separated, `num_heads` should be provided.")
+            self.apply_local_relpe = self.apply_local_relpe_fused
             cache = cache.repeat(1, 1, num_heads)
             # cache: bs (1), seqlen, head embed dim * num heads
         self.register_buffer("rel_pos_emb", cache, persistent=False)
@@ -249,12 +260,17 @@ class TrigRelPEBase(RelPEBase):
     def apply_relpe(self, x: torch.Tensor) -> torch.Tensor:
         return x * self.rel_pos_emb
 
-    def apply_local_relpe(self, x: torch.Tensor, window_size, num_windows):
+    def apply_local_relpe_fused(self, x: torch.Tensor, window_size, num_windows):
         """Applies RelPE in a way that treats local attention windows as
         independent sequences. It's assumed that input `x` is of form
-        (bs, num_windows * window_size, num_heads * head_dim) or
-        (bs, num_heads, num_windows * window_size, head_dim), depending on init."""
+        (bs, num_windows * window_size, num_heads * head_dim)."""
         return x * self.rel_pos_emb[..., :window_size, :].repeat(1, num_windows, 1)
+
+    def apply_local_relpe_sep(self, x: torch.Tensor, window_size, num_windows):
+        """Applies RelPE in a way that treats local attention windows as
+        independent sequences. It's assumed that input `x` is of form
+        (bs, num_heads, num_windows * window_size, head_dim)."""
+        return x * self.rel_pos_emb[..., :window_size, :].repeat(1, 1, num_windows, 1)
 
     def apply_local_relpe2(self, x: torch.Tensor, window_size, num_windows):
         """Applies RelPE in a way that treats local attention windows as

--- a/src/positional_embeddings.py
+++ b/src/positional_embeddings.py
@@ -107,7 +107,7 @@ class RoPE(RelPEBase):
         # 1st repeat is for x1 and the 2nd is for x2 coordinate in 2-dimensional
         # (x1, x2) vectors that comprise the whole head embedding dimension.
         # It's assumed in this implementation that all x1s are stored at first
-        # withing the dim, and only then all x2s.
+        # within the dim, and only then all x2s.
         angles = torch.outer(seq_idx, theta).repeat(1, 2).float()
         self.rotate_half = self.rotate_half_classic
 
@@ -179,8 +179,16 @@ class RoPE(RelPEBase):
     def apply_local_relpe2(self, x: torch.Tensor, window_size, num_windows):
         """Applies RoPE in a way that treats local attention windows as
         independent sequences. It's assumed that input `x` is of form
-        (bs, num_windows, num_heads, window_size, head_dim) and RoPE cache is
-        (bs (1), num_heads (1), seqlen, head_dim) """
+        (bs, num_windows, num_heads, window_size, head_dim) or
+        (bs, num_windows, window_size, num_heads * head_dim),
+        and that RoPE cache is respectively
+        (bs (1), num_windows (1), num_heads (1), window_size, head_dim)
+        or (bs (1), num_windows (1), window_size, num_heads * head_dim).
+
+        This method has the same effect as `apply_relpe`, because by definition
+        seq_len = window_size and additional `num_windows` dim is broadcasted
+        either way. It will be deprecated in a future release.
+        """
         cache_cos = self.cache_cos.unsqueeze(0)[..., :window_size, :]
         cache_sin = self.cache_sin.unsqueeze(0)[..., :window_size, :]
         pdtype = x.dtype
@@ -251,7 +259,14 @@ class TrigRelPEBase(RelPEBase):
     def apply_local_relpe2(self, x: torch.Tensor, window_size, num_windows):
         """Applies RelPE in a way that treats local attention windows as
         independent sequences. It's assumed that input `x` is of form
-        (bs, num_windows, num_heads, window_size, head_dim)"""
+        (bs, num_windows, num_heads, window_size, head_dim) or
+        (bs, num_windows (1), window_size, num_heads * head_dim).
+
+        This method has the same effect as `apply_relpe`, because by definition
+        seq_len = window_size and additional `num_windows` dim is broadcasted
+        either way. It will be deprecated in a future release.
+        """
+
         return x * self.rel_pos_emb.unsqueeze(0)[..., :window_size, :]
 
 class CosRelPE(TrigRelPEBase):

--- a/src/positional_embeddings.py
+++ b/src/positional_embeddings.py
@@ -103,9 +103,13 @@ class RoPE(RelPEBase):
         # Create position indexes `[0, 1, ..., seq_len - 1]`
         seq_idx = torch.arange(seq_len)
 
+
         # Calculate the product of position index and $\theta_i$
         angles = torch.outer(seq_idx, theta).repeat(1, 2).float()
-
+        self.rotate_half = self.rotate_half_classic
+        if num_heads is not None and num_heads > 1:
+            angles = torch.outer(seq_idx, theta).repeat_interleave(2, 1).float()
+            self.rotate_half = self.rotate_half_fused_dims
         cache_cos = torch.cos(angles).unsqueeze(0)
         cache_sin = torch.sin(angles).unsqueeze(0)
         if num_heads is None:
@@ -120,13 +124,24 @@ class RoPE(RelPEBase):
         self.register_buffer("cache_sin", cache_sin, persistent=False)
 
     @staticmethod
-    def rotate_half(x):
+    def rotate_half_classic(x):
         """Rotates half the hidden dims of the input.
         From https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L84
         """
         x1 = x[..., : x.shape[-1] // 2]
         x2 = x[..., x.shape[-1] // 2:]
         return torch.cat((-x2, x1), dim=-1)
+
+    @staticmethod
+    def rotate_half_fused_dims(x):
+        """A version of the rotate half function for the case where head and
+        embedding dimensions are not decoupled.
+        """
+        # x = (x0, x1, x2, x3, ...), y = (-x1, x0, -x3, x2, ...)
+        y = torch.empty_like(x)
+        y[..., 0::2] = - x[..., 1::2]
+        y[..., 1::2] = x[..., 0::2]
+        return y
 
     def apply_relpe(self, x: torch.Tensor) -> torch.Tensor:
         # truncate to support variable sizes

--- a/src/positional_embeddings.py
+++ b/src/positional_embeddings.py
@@ -47,7 +47,7 @@ class RelPEBase(nn.Module, abc.ABC):
 
 class DummyRelPE(RelPEBase):
     def __init__(self, seq_len: int, n_elem: int,
-                 base: int = 10000, num_heads=None):
+                 base: int = 10000, sep_head_dim=True, num_heads=None):
         super(DummyRelPE, self).__init__()
         self.rel_pos_emb = None
 
@@ -62,13 +62,11 @@ class DummyRelPE(RelPEBase):
 
 class RoPE(RelPEBase):
     def __init__(self, seq_len: int, n_elem: int,
-                 base: int = 10000, num_heads=None, emb_fraction=1.0):
+                 base: int = 10000, sep_head_dim=True, num_heads=None,
+                 emb_fraction=1.0):
         super(RoPE, self).__init__()
-        """Enhanced Transformer with Rotary Position Embedding.
-
-        Derived from: https://github.com/labmlai/annotated_deep_learning_paper_implementations/blob/master/labml_nn/transformers/rope/__init__.py. 
-        MIT License:
-        https://github.com/labmlai/annotated_deep_learning_paper_implementations/blob/master/license.
+        """RoPE embeddings from the paper https://arxiv.org/abs/2104.09864.
+        'Enhanced Transformer with Rotary Position Embedding.'
         
         Parameters
         ----------
@@ -79,10 +77,13 @@ class RoPE(RelPEBase):
             Embedding dimension of one head
         base : int
             RoPE \Theta base. Default is 10000.     
+        sep_head_dim : bool, optional
+            Determines whether the head dimension should be separated from the
+            embedding dim. If yes, then cached RoPE buffers take form of 
+            `bs (1), headdim (1), seqlen, n_elem`. Otherwise, the form is
+            `bs (1), seqlen, n_elem`. Default is True.
         num_heads : int, optional
-            Number of heads. Defaults to None. If supplied, cached RoPE buffers 
-            take form of `bs (1), seqlen, n_elem * num_heads`, else 
-            `bs (1), headdim (1), seqlen, n_elem`.
+            Number of heads. Default is None.
         emb_fraction: float
             Fraction of the embedding dimension to which RoPE should be 
             applied. Default is 1.
@@ -103,23 +104,33 @@ class RoPE(RelPEBase):
         # Create position indexes `[0, 1, ..., seq_len - 1]`
         seq_idx = torch.arange(seq_len)
 
-
-        # Calculate the product of position index and $\theta_i$
+        # 1st repeat is for x1 and the 2nd is for x2 coordinate in 2-dimensional
+        # (x1, x2) vectors that comprise the whole head embedding dimension.
+        # It's assumed in this implementation that all x1s are stored at first
+        # withing the dim, and only then all x2s.
         angles = torch.outer(seq_idx, theta).repeat(1, 2).float()
         self.rotate_half = self.rotate_half_classic
-        if num_heads is not None and num_heads > 1:
-            angles = torch.outer(seq_idx, theta).repeat_interleave(2, 1).float()
-            self.rotate_half = self.rotate_half_fused_dims
+
         cache_cos = torch.cos(angles).unsqueeze(0)
         cache_sin = torch.sin(angles).unsqueeze(0)
-        if num_heads is None:
+        # cache: bs (1), seqlen, head embed dim
+        if sep_head_dim:
             cache_cos = cache_cos.unsqueeze(1)
             cache_sin = cache_sin.unsqueeze(1)
-            # cache: bs (1), headdim (1), seqlen, embed dim
+            # cache: bs (1), headdim (1), seqlen, head embed dim
         else:
+            if num_heads is None:
+                raise ValueError("If head and embedding dimensions are not "
+                                 "separated, `num_heads` should be provided.")
             cache_cos = cache_cos.repeat(1, 1, num_heads)
             cache_sin = cache_sin.repeat(1, 1, num_heads)
-            # cache: bs (1), seqlen, embed dim * num heads
+            # cache: bs (1), seqlen, head embed dim * num heads
+            if num_heads > 1:
+                # Branch for correct RoPE calculation in setting of multiple
+                # heads and merged head-embedding dimensions.
+                self.n_heads = num_heads
+                self.rotate_half = self.rotate_half_fused_dims
+
         self.register_buffer("cache_cos", cache_cos, persistent=False)
         self.register_buffer("cache_sin", cache_sin, persistent=False)
 
@@ -132,16 +143,14 @@ class RoPE(RelPEBase):
         x2 = x[..., x.shape[-1] // 2:]
         return torch.cat((-x2, x1), dim=-1)
 
-    @staticmethod
-    def rotate_half_fused_dims(x):
+    def rotate_half_fused_dims(self, x):
         """A version of the rotate half function for the case where head and
         embedding dimensions are not decoupled.
         """
-        # x = (x0, x1, x2, x3, ...), y = (-x1, x0, -x3, x2, ...)
-        y = torch.empty_like(x)
-        y[..., 0::2] = - x[..., 1::2]
-        y[..., 1::2] = x[..., 0::2]
-        return y
+        size = x.size()
+        x = x.view(size[:-1] + (self.n_heads, size[-1] // self.n_heads))
+        x = self.rotate_half_classic(x)
+        return x.view(size)
 
     def apply_relpe(self, x: torch.Tensor) -> torch.Tensor:
         # truncate to support variable sizes
@@ -181,22 +190,48 @@ class RoPE(RelPEBase):
         return x.to(pdtype)
 
 class TrigRelPEBase(RelPEBase):
-    """Use num_heads=None if you intend to apply RelPE to tensors which
-    already have material head dimension. If all heads are implicitly
-    stored in one dimension or there's only one head, put their number, and
-    the algorithm will repeat n_elem to cover the whole dimension."""
+    """
+    Base class for trigonometric RelPE (Cosine, Cos - Sin, etc.) from
+    'MatMuls are Enough for Efficient and Performant Linear-Time Attention'
+
+    Use sep_head_dim=None if you intend to apply RelPE to tensors which already
+    have material head dimension. If all heads are implicitly stored in one
+    dimension or there's only one head, the algorithm will repeat the head dim
+    of `n_elem` elements `num_heads` times to cover the whole embedding
+    dimension.
+
+    Parameters
+    ----------
+    seq_len : int
+        Maximum length of input sequence. RoPE cache will have this length
+        in the sequence dimension.
+    n_elem : int
+        Embedding dimension of one head
+    base : int
+        RoPE \Theta base. Default is 10000.
+    sep_head_dim : bool, optional
+        Determines whether the head dimension should be separated from the
+        embedding dim. If yes, then cached RoPE buffers take form of
+        `bs (1), headdim (1), seqlen, n_elem`. Otherwise, the form is
+        `bs (1), seqlen, n_elem * num_heads`. Default is True.
+    num_heads : int, optional
+        Number of heads. Default is None.
+    """
     def __init__(self, seq_len: int, n_elem: int,
-                 base: int = 10000, num_heads=None):
+                 base: int = 10000, sep_head_dim=True, num_heads=None):
         super(TrigRelPEBase, self).__init__()
         theta = 1.0 / (base ** (torch.arange(0, n_elem) / n_elem))
         angles: torch.Tensor = torch.outer(torch.arange(seq_len), theta)
         cache = self.trig_transform(angles).unsqueeze(0)
-        if num_heads is None:
+        if sep_head_dim:
             cache = cache.unsqueeze(1)
-            # cache: bs (1), headdim (1), seqlen, embed dim
+            # cache: bs (1), headdim (1), seqlen, head embed dim
         else:
+            if num_heads is None:
+                raise ValueError("If head and embedding dimensions are not "
+                                 "separated, `num_heads` should be provided.")
             cache = cache.repeat(1, 1, num_heads)
-            # cache: bs (1), seqlen, embed dim * num heads
+            # cache: bs (1), seqlen, head embed dim * num heads
         self.register_buffer("rel_pos_emb", cache, persistent=False)
 
     @staticmethod

--- a/src/positional_embeddings.py
+++ b/src/positional_embeddings.py
@@ -165,6 +165,9 @@ class RoPE(RelPEBase):
         x = x * cache_cos + self.rotate_half(x) * cache_sin
         return x.to(pdtype)
 
+    def apply_local_relpe(self, x: torch.Tensor, window_size, num_windows):
+        raise RuntimeError("This method should have been overridden in init.")
+
     def apply_local_relpe_fused(self, x: torch.Tensor, window_size, num_windows):
         """Applies RoPE in a way that treats local attention windows as
         independent sequences. It's assumed that input `x` is of form
@@ -259,6 +262,9 @@ class TrigRelPEBase(RelPEBase):
 
     def apply_relpe(self, x: torch.Tensor) -> torch.Tensor:
         return x * self.rel_pos_emb
+
+    def apply_local_relpe(self, x: torch.Tensor, window_size, num_windows):
+        raise RuntimeError("This method should have been overridden in init.")
 
     def apply_local_relpe_fused(self, x: torch.Tensor, window_size, num_windows):
         """Applies RelPE in a way that treats local attention windows as

--- a/tests/src/test_positional_embeddings.py
+++ b/tests/src/test_positional_embeddings.py
@@ -1,0 +1,259 @@
+import torch
+import pytest
+
+from src.positional_embeddings import RoPE, RelPEBase
+
+
+class ReferenceRoPE(RelPEBase):
+    def __init__(self, seq_len: int, n_elem: int,
+                 base: int = 10000, num_heads=None, emb_fraction=1.0):
+        super(ReferenceRoPE, self).__init__()
+        """Reference RoPE implementation which handles merged head and 
+        embedding (num_h+dim) dimensions correctly.
+
+        Parameters
+        ----------
+        seq_len : int
+            Maximum length of input sequence. RoPE cache will have this length 
+            in the sequence dimension.     
+        n_elem : int
+            Embedding dimension of one head
+        base : int
+            RoPE \Theta base. Default is 10000.     
+        num_heads : int, optional
+            Number of heads. Defaults to None. If supplied, cached RoPE buffers 
+            take form of `bs (1), seqlen, n_elem * num_heads`, else 
+            `bs (1), headdim (1), seqlen, n_elem`.
+        emb_fraction: float
+            Fraction of the embedding dimension to which RoPE should be 
+            applied. Default is 1.
+        """
+        # $\Theta = {\theta_i = 10000^{\frac{2(i-1)}{d}}, i \in [1, 2, ..., \frac{d}{2}]}$
+        theta = 1.0 / (base ** (torch.arange(0, n_elem, 2) / n_elem))
+        # theta = 1.0 / (base ** (torch.ones(n_elem // 2) / n_elem))
+
+        if emb_fraction != 1.0:
+            n_elem_rope = int(n_elem * emb_fraction)
+            # RoPE dimension should be divisible by 2.
+            n_elem_rope = n_elem_rope - n_elem_rope % 2
+            theta_rope = 1.0 / (base ** (torch.arange(0, n_elem_rope, 2)
+                                         / n_elem_rope))
+            theta = torch.ones(size=(n_elem // 2,))
+            theta[:n_elem_rope // 2] = theta_rope
+
+        # Create position indexes `[0, 1, ..., seq_len - 1]`
+        seq_idx = torch.arange(seq_len)
+
+        # Calculate the product of position index and $\theta_i$
+        angles = torch.outer(seq_idx, theta).repeat(1, 2).float()
+        self.rotate_half = self.rotate_half_classic
+        if num_heads is not None and num_heads > 1:
+            angles = torch.outer(seq_idx, theta).repeat_interleave(2, 1).float()
+            self.rotate_half = self.rotate_half_fused_dims
+        cache_cos = torch.cos(angles).unsqueeze(0)
+        cache_sin = torch.sin(angles).unsqueeze(0)
+        if num_heads is None:
+            cache_cos = cache_cos.unsqueeze(1)
+            cache_sin = cache_sin.unsqueeze(1)
+            # cache: bs (1), headdim (1), seqlen, embed dim
+        else:
+            cache_cos = cache_cos.repeat(1, 1, num_heads)
+            cache_sin = cache_sin.repeat(1, 1, num_heads)
+            # cache: bs (1), seqlen, embed dim * num heads
+        self.register_buffer("cache_cos", cache_cos, persistent=False)
+        self.register_buffer("cache_sin", cache_sin, persistent=False)
+
+    @staticmethod
+    def rotate_half_classic(x):
+        """Rotates half the hidden dims of the input.
+        From https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L84
+        """
+        x1 = x[..., : x.shape[-1] // 2]
+        x2 = x[..., x.shape[-1] // 2:]
+        return torch.cat((-x2, x1), dim=-1)
+
+    @staticmethod
+    def rotate_half_fused_dims(x):
+        """A version of the rotate half function for the case where head and
+        embedding dimensions are not decoupled.
+        """
+        # x = (x0, x1, x2, x3, ...), y = (-x1, x0, -x3, x2, ...)
+        y = torch.empty_like(x)
+        y[..., 0::2] = - x[..., 1::2]
+        y[..., 1::2] = x[..., 0::2]
+        return y
+
+    def apply_relpe(self, x: torch.Tensor) -> torch.Tensor:
+        # truncate to support variable sizes
+        seq_len = x.size(-2)
+        cache_cos = self.cache_cos[..., :seq_len, :]
+        cache_sin = self.cache_sin[..., :seq_len, :]
+        pdtype = x.dtype
+        # First half of the tensor [x1, x2] takes form x1 * cos - x2 * sin
+        # Second half is x1 * cos + x2 * sin
+        x = x * cache_cos + self.rotate_half(x) * cache_sin
+        return x.to(pdtype)
+
+    def apply_local_relpe(self, x: torch.Tensor, window_size, num_windows):
+        """Applies RoPE in a way that treats local attention windows as
+        independent sequences. It's assumed that input `x` is of form
+        (bs, num_windows * window_size, num_heads * head_dim) or
+        (bs, num_heads, num_windows * window_size, head_dim), depending on init."""
+        cache_cos = self.cache_cos[..., :window_size, :].repeat(1, num_windows, 1)
+        cache_sin = self.cache_sin[..., :window_size, :].repeat(1, num_windows, 1)
+        pdtype = x.dtype
+        # First half of the tensor [x1, x2] takes form x1 * cos - x2 * sin
+        # Second half is x1 * cos + x2 * sin
+        x = x * cache_cos + self.rotate_half(x) * cache_sin
+        return x.to(pdtype)
+
+    def apply_local_relpe2(self, x: torch.Tensor, window_size, num_windows):
+        """Applies RoPE in a way that treats local attention windows as
+        independent sequences. It's assumed that input `x` is of form
+        (bs, num_windows, num_heads, window_size, head_dim) or
+        (bs, num_windows, window_size, num_heads * head_dim),
+        and that RoPE cache is respectively
+        (bs (1), num_windows (1), num_heads (1), window_size, head_dim)
+        or (bs (1), num_windows (1), window_size, num_heads * head_dim).
+
+        This method has the same effect as `apply_relpe`, because by definition
+        seq_len = window_size and additional `num_windows` dim is broadcasted
+        either way. It will be deprecated in a future release.
+        """
+        cache_cos = self.cache_cos.unsqueeze(0)[..., :window_size, :]
+        cache_sin = self.cache_sin.unsqueeze(0)[..., :window_size, :]
+        pdtype = x.dtype
+        # First half of the tensor [x1, x2] takes form x1 * cos - x2 * sin
+        # Second half is x1 * cos + x2 * sin
+        x = x * cache_cos + self.rotate_half(x) * cache_sin
+        return x.to(pdtype)
+
+
+@pytest.mark.parametrize(
+    "seq_len, head_dim, window_size",
+    [
+        (32, 64, 8),
+        (21, 32, 7),
+        (33, 16, 11),
+    ],
+)
+@pytest.mark.parametrize("num_heads", [1, 4, 8])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_rope_all_methods_one_func(seq_len, head_dim, num_heads, window_size, dtype):
+    """
+    Compares different RoPE methods in one function:
+    Test cases:
+      - apply_relpe (merged num_h+dim) == apply_relpe (reference)
+      - apply_relpe (merged num_h+dim) == apply_relpe (separate num_h+dim)
+      - apply_local_relpe (merged num_h+dim) == apply_local_relpe (reference)
+      - apply_local_relpe (merged num_h+dim) != apply_relpe (merged num_h+dim)
+        if window_size != seq_len
+      - apply_local_relpe (merged num_h+dim) == apply_relpe (merged num_h+dim)
+        if window_size == seq_len
+      - apply_local_relpe (merged num_h+dim) == apply_local_relpe (sep. num_h+dim)
+      - apply_local_relpe2 (merged num_h+dim) == apply_local_relpe2 (sep. num_h+dim)
+      - apply_local_relpe2 (merged num_h+dim) == apply_local_relpe (merged num_h+dim)
+
+    By transitivity, success of these test cases implies that more equalities
+    hold, e.g.,
+    apply_local_relpe2 (sep. num_h+dim) = apply_local_relpe (sep. num_h+dim).
+    """
+    if head_dim % 2 != 0:
+        pytest.skip("RoPE requires even head_dim")
+    assert seq_len % window_size == 0, "window_size must divide seq_len"
+    num_windows = seq_len // window_size
+    # Constants: batch_size, relative and absolute tolerances
+    B = 3
+    RTOL = 1e-5
+    ATOL = 1e-5
+    torch.manual_seed(1234)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # Instantiation of RoPE classes for merged and separated num_h+dim
+    # dimensions cases and of the reference class.
+    rope_h_merged = RoPE(
+        seq_len=seq_len, n_elem=head_dim, base=10000, sep_head_dim=False,
+        num_heads=num_heads,
+    ).to(device)
+    rope_h_sep = RoPE(
+        seq_len=seq_len, n_elem=head_dim, base=10000, sep_head_dim=True,
+        num_heads=num_heads,
+    ).to(device)
+    ref_rope = ReferenceRoPE(
+        seq_len=seq_len, n_elem=head_dim, base=10000, num_heads=num_heads,
+    ).to(device)
+
+    # Instantiation of different shapes of one random input tensor.
+    x_raw = torch.randn(B, seq_len, num_heads, head_dim,
+                        device=device, dtype=dtype)
+    x = x_raw.view(B, seq_len, num_heads * head_dim)
+    x_w_sep = x_raw.view(B, num_windows, window_size, num_heads * head_dim)
+    x_h_sep = x_raw.permute(0, 2, 1, 3)
+    # x_h_sep: B, num_heads, seq_len, head_dim
+    x_h_sep_w_sep = x_h_sep.reshape(B, num_heads, num_windows,
+                                    window_size, head_dim)
+
+
+    # apply_relpe
+    out_rope = rope_h_merged.apply_relpe(x)
+    out_ref = ref_rope.apply_relpe(x)
+    out_rope_sep = rope_h_sep.apply_relpe(x_h_sep)
+    assert out_rope.shape == out_ref.shape == (B, seq_len, num_heads * head_dim)
+    # Merged and reference merged implementations should be equal
+    assert torch.allclose(out_rope, out_ref, rtol=RTOL, atol=ATOL)
+    assert out_rope_sep.shape == (B, num_heads, seq_len, head_dim)
+    out_rope_sep = (out_rope_sep.permute(0, 2, 1, 3)
+                    .reshape(B, seq_len, num_heads * head_dim))
+    # Two ways of RoPE calculation (merged and separated heads) should be equal.
+    assert torch.allclose(out_rope, out_rope_sep, rtol=RTOL, atol=ATOL)
+
+    # apply_local_relpe
+    out_rope_loc = rope_h_merged.apply_local_relpe(x, window_size=window_size,
+                                                   num_windows=num_windows)
+    out_ref_loc = ref_rope.apply_local_relpe(x, window_size=window_size,
+                                             num_windows=num_windows)
+    out_rope_sep_loc = rope_h_sep.apply_local_relpe(
+        x_h_sep, window_size=window_size, num_windows=num_windows
+    )
+    assert out_rope_loc.shape == out_ref_loc.shape == (B, seq_len, num_heads * head_dim)
+    # Merged and reference merged implementations should be equal
+    assert torch.allclose(out_rope_loc, out_ref_loc, rtol=RTOL, atol=ATOL)
+    # Together, the two clauses below test that
+    # (window_size == seq_len) <=> (local RoPE == global RoPE).
+    # 1. (window_size != seq_len) => (local RoPE != global RoPE)
+    assert window_size == seq_len or not torch.allclose(out_rope_loc, out_rope,
+                                                        rtol=RTOL, atol=ATOL)
+    # 2. (window_size == seq_len) => (local RoPE == global RoPE)
+    assert torch.allclose(out_rope_loc[:, :window_size, ...],
+                          out_rope[:, :window_size, ...], rtol=RTOL, atol=ATOL)
+
+    assert out_rope_sep_loc.shape == (B, num_heads, seq_len, head_dim)
+    out_rope_sep_loc = (out_rope_sep_loc.permute(0, 2, 1, 3)
+                        .reshape(B, seq_len, num_heads * head_dim))
+    # Two ways of local RoPE calculation (merged and separated heads) should
+    # be equal.
+    assert torch.allclose(out_rope_loc, out_rope_sep_loc, rtol=RTOL, atol=ATOL)
+
+
+    # apply_local_relpe2
+    out_rope_loc2 = rope_h_merged.apply_local_relpe2(
+        x_w_sep, window_size=window_size, num_windows=num_windows
+    )
+    assert out_rope_loc2.shape == (
+        B, num_windows, window_size, num_heads * head_dim)
+    out_rope_sep_loc2 = ref_rope.apply_local_relpe2(
+        x_h_sep_w_sep, window_size=window_size, num_windows=num_windows
+    )
+    assert out_rope_sep_loc2.shape == (
+        B, num_heads, num_windows, window_size, head_dim)
+    out_rope_sep_loc2 = (
+        out_rope_sep_loc2.permute(0, 2, 3, 1, 4)
+        .reshape(B, num_windows, window_size, num_heads * head_dim)
+    )
+    # Separate and merged heads methods should yield equal results
+    assert torch.allclose(out_rope_loc2, out_rope_sep_loc2, rtol=RTOL, atol=ATOL)
+    out_rope_loc2 = out_rope_loc2.view(B, seq_len, num_heads * head_dim)
+    # `apply_local_relpe` and `apply_local_relpe2` functions should yield the
+    # same results.
+    assert torch.allclose(out_rope_loc2, out_rope_loc, rtol=RTOL, atol=ATOL)
+

--- a/tests/src/test_positional_embeddings.py
+++ b/tests/src/test_positional_embeddings.py
@@ -130,22 +130,20 @@ class ReferenceRoPE(RelPEBase):
 
 
 @pytest.mark.parametrize(
-    "seq_len, head_dim, window_size",
-    [
-        (32, 64, 8),
-        (21, 32, 7),
-        (33, 16, 11),
-    ],
+    "seq_len, window_size", [(32, 8), (21, 7), (33, 11)]
 )
-@pytest.mark.parametrize("num_heads", [1, 4, 8])
+@pytest.mark.parametrize("head_dim", [2, 16, 32, 64])
+@pytest.mark.parametrize("num_heads", [1, 5, 8])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 def test_rope_all_methods_one_func(seq_len, head_dim, num_heads, window_size, dtype):
     """
     Compares different RoPE methods in one function:
     Test cases:
       - apply_relpe (merged num_h+dim) == apply_relpe (reference)
+        if num_h == 1 or dim == 2
       - apply_relpe (merged num_h+dim) == apply_relpe (separate num_h+dim)
       - apply_local_relpe (merged num_h+dim) == apply_local_relpe (reference)
+        if num_h == 1 or dim == 2
       - apply_local_relpe (merged num_h+dim) != apply_relpe (merged num_h+dim)
         if window_size != seq_len
       - apply_local_relpe (merged num_h+dim) == apply_relpe (merged num_h+dim)
@@ -156,7 +154,7 @@ def test_rope_all_methods_one_func(seq_len, head_dim, num_heads, window_size, dt
 
     By transitivity, success of these test cases implies that more equalities
     hold, e.g.,
-    apply_local_relpe2 (sep. num_h+dim) = apply_local_relpe (sep. num_h+dim).
+    apply_local_relpe2 (sep. num_h+dim) = apply_local_relpe (merged num_h+dim).
     """
     if head_dim % 2 != 0:
         pytest.skip("RoPE requires even head_dim")
@@ -199,8 +197,10 @@ def test_rope_all_methods_one_func(seq_len, head_dim, num_heads, window_size, dt
     out_ref = ref_rope.apply_relpe(x)
     out_rope_sep = rope_h_sep.apply_relpe(x_h_sep)
     assert out_rope.shape == out_ref.shape == (B, seq_len, num_heads * head_dim)
-    # Merged and reference merged implementations should be equal
-    assert torch.allclose(out_rope, out_ref, rtol=RTOL, atol=ATOL)
+    # Merged and reference merged implementations should be equal for single
+    # head or head dimension of 2 elements.
+    if num_heads == 1 or head_dim == 2:
+        assert torch.allclose(out_rope, out_ref, rtol=RTOL, atol=ATOL)
     assert out_rope_sep.shape == (B, num_heads, seq_len, head_dim)
     out_rope_sep = (out_rope_sep.permute(0, 2, 1, 3)
                     .reshape(B, seq_len, num_heads * head_dim))
@@ -212,12 +212,11 @@ def test_rope_all_methods_one_func(seq_len, head_dim, num_heads, window_size, dt
                                                    num_windows=num_windows)
     out_ref_loc = ref_rope.apply_local_relpe(x, window_size=window_size,
                                              num_windows=num_windows)
-    out_rope_sep_loc = rope_h_sep.apply_local_relpe(
-        x_h_sep, window_size=window_size, num_windows=num_windows
-    )
     assert out_rope_loc.shape == out_ref_loc.shape == (B, seq_len, num_heads * head_dim)
-    # Merged and reference merged implementations should be equal
-    assert torch.allclose(out_rope_loc, out_ref_loc, rtol=RTOL, atol=ATOL)
+    # Merged and reference merged implementations should be equal for single
+    # head or head dimension of 2 elements.
+    if num_heads == 1 or head_dim == 2:
+        assert torch.allclose(out_rope_loc, out_ref_loc, rtol=RTOL, atol=ATOL)
     # Together, the two clauses below test that
     # (window_size == seq_len) <=> (local RoPE == global RoPE).
     # 1. (window_size != seq_len) => (local RoPE != global RoPE)
@@ -227,6 +226,9 @@ def test_rope_all_methods_one_func(seq_len, head_dim, num_heads, window_size, dt
     assert torch.allclose(out_rope_loc[:, :window_size, ...],
                           out_rope[:, :window_size, ...], rtol=RTOL, atol=ATOL)
 
+    out_rope_sep_loc = rope_h_sep.apply_local_relpe(
+        x_h_sep, window_size=window_size, num_windows=num_windows
+    )
     assert out_rope_sep_loc.shape == (B, num_heads, seq_len, head_dim)
     out_rope_sep_loc = (out_rope_sep_loc.permute(0, 2, 1, 3)
                         .reshape(B, seq_len, num_heads * head_dim))
@@ -241,7 +243,7 @@ def test_rope_all_methods_one_func(seq_len, head_dim, num_heads, window_size, dt
     )
     assert out_rope_loc2.shape == (
         B, num_windows, window_size, num_heads * head_dim)
-    out_rope_sep_loc2 = ref_rope.apply_local_relpe2(
+    out_rope_sep_loc2 = rope_h_sep.apply_local_relpe2(
         x_h_sep_w_sep, window_size=window_size, num_windows=num_windows
     )
     assert out_rope_sep_loc2.shape == (


### PR DESCRIPTION
This PR does the following:

* Add sleep interval in case of failure to save a checkpoint before retrying;
* Fix a bug with _forward_chunked when seq_len is not divisible by chunk_size;
* Fix a mistake with incorrect RoPE application for DenseAttention with multiple heads;
* Improve the speed of RoPE for DenseAttention in case of multiple heads;
* Make RelPE initialization arguments more intuitive;
* Add support for separate head and embedding dimension in `apply_local_relpe` functions of RoPE and TrigRelPE;
* Improve documentation related to RelPE in src/dense_attention.py and src/positional_embeddings.py;
* Add tests for the RoPE methods and improve documentation of RoPE;
